### PR TITLE
fix: move PFG widget to sky above truck (top: 42% → top: 8%)

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@ body {
   -webkit-tap-highlight-color: transparent;
   transition: background .2s;
 }
-@media(min-width: 420px) { .gw { padding: 9px 13px; border-radius: 10px; right: 14px; top: 40%; } }
+@media(min-width: 420px) { .gw { padding: 9px 13px; border-radius: 10px; right: 14px; } }
 @media(min-width: 768px) { .gw { top: 72px; right: 60px; padding: 10px 16px; } }
 .gw:hover, .gw:active { background: rgba(13,27,42,.48); }
 


### PR DESCRIPTION
The .gw CSS class had `top: 42%` which placed the PFG widget over the truck in the hero image. Changed to `top: 8%` so the widget sits in the open sky area in the upper-right of the hero, above the truck.