### PR TITLE
[Bug] Wire gtag init so dataLayer events actually fire

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <link rel="canonical" href="https://talewatersandtides.com">
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
 <script async src="https://www.googletagmanager.com/gtag/js?id=GTM-TZVTR5TG"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','GTM-TZVTR5TG');</script>
 <style>
 /* ============================================================
    TALE WATERS & TIDES — Mobile-First CSS

--- a/projects/buffalo-river/index.html
+++ b/projects/buffalo-river/index.html
@@ -14,6 +14,7 @@
 <link rel="canonical" href="https://talewatersandtides.com/projects/buffalo-river/">
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
 <script async src="https://www.googletagmanager.com/gtag/js?id=GTM-TZVTR5TG"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','GTM-TZVTR5TG');</script>
 <style>
 :root {
   --tl: #2a6b8a;

--- a/projects/index.html
+++ b/projects/index.html
@@ -13,6 +13,7 @@
 <link rel="canonical" href="https://talewatersandtides.com/projects/">
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
 <script async src="https://www.googletagmanager.com/gtag/js?id=GTM-TZVTR5TG"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','GTM-TZVTR5TG');</script>
 <style>
 :root {
   --tl: #2a6b8a;


### PR DESCRIPTION
## Summary

- Adds the standard gtag init snippet immediately after the existing async `gtag.js` loader on all three pages: `index.html`, `projects/index.html`, `projects/buffalo-river/index.html`
- Defines `window.dataLayer`, the `gtag` stub, sends the `js` timestamp, and runs `gtag('config', 'GTM-TZVTR5TG')`
- Surfaced as part of resolving the line-16 review comment on PR #20 — the issue was site-wide, not buffalo-river-specific

## Why

Before this change, every page loaded `gtag.js` but never ran the init boilerplate. `window.gtag` was undefined, and every `data-ga` click handler and `section_view` IntersectionObserver was gated on `typeof gtag === 'function'`, so all events silently no-op'd. Nothing was reaching `dataLayer`.

## What now lands in dataLayer

Verified in headless Chromium on all three pages — first three entries:

```
["js", "2026-05-21T05:01:04.114Z"]
["config", "GTM-TZVTR5TG"]
["event", "section_view", { event_category: "scroll", event_label: "<section>" }]
```

`window.gtag` is a function. No page errors. No console errors.

## Note (not changed in this PR)

The ID `GTM-TZVTR5TG` is a GTM container ID, which `gtag.js` doesn't officially support (it expects `G-*` GA4 or `UA-*` UA IDs). The init snippet pushes `config` events to `dataLayer` and the request to googletagmanager.com returns 200, so events land — but if the destination property is a real GTM container, the proper fix is to swap in the GTM container snippet (`gtm.js` + the iframe noscript). Flagged for a follow-up; this PR is scoped to "make events actually fire" with the existing loader.

## Test plan

- [x] `index.html` — hasGtag true, dataLayer initialized, `section_view` events fire on scroll
- [x] `projects/index.html` — same
- [x] `projects/buffalo-river/index.html` — same
- [x] No JS errors, no failed requests (excluding fonts) in headless Chromium at 1280-wide
- [ ] After merge: confirm events appear in the destination property in real-time view (only @sirgaladad has access)

https://claude.ai/code/session_01BKwpmkgvAB5xKuX4pVsJPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKwpmkgvAB5xKuX4pVsJPR)_