### PR TITLE
[Feature] Prompt Play — ROLLER booking links

### DIFF
--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -157,10 +157,10 @@ section { padding: 52px 0; }
 .reserve .sec-lead { margin: 0 auto; }
 .seats { display: inline-flex; align-items: center; gap: 8px; margin-top: 18px; font-family: var(--fd); font-weight: 600; color: var(--coral); background: rgba(232,101,78,.12); border: 1px solid rgba(232,101,78,.3); padding: 8px 18px; border-radius: 999px; }
 .seats svg { width: 17px; height: 17px; }
-.luma-embed { max-width: 760px; margin: 28px auto 0; }
-.luma-embed iframe { width: 100%; min-height: 580px; border: 1px solid #bfcbda88; border-radius: 14px; background: var(--cream); box-shadow: 0 10px 30px rgba(20,50,74,.08); }
-.luma-note { margin-top: 14px; font-size: .85rem; color: var(--muted); display: inline-flex; align-items: center; gap: 7px; }
-.luma-note svg { width: 15px; height: 15px; color: var(--teal); }
+.book-row { display: flex; flex-wrap: wrap; gap: 14px; justify-content: center; margin: 28px auto 0; max-width: 820px; }
+.book-row .btn { flex: 1 1 240px; max-width: 340px; }
+.book-note { margin-top: 16px; font-size: .85rem; color: var(--muted); display: inline-flex; align-items: center; gap: 7px; }
+.book-note svg { width: 15px; height: 15px; color: var(--teal); }
 .reserve-actions { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 26px; }
 
 /* ============================================================ TWO-COL (who / bring) */
@@ -320,7 +320,7 @@ section { padding: 52px 0; }
         <h3>First Contact</h3>
         <div class="nite-when"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>Tue, June 2, 2026 · 7–9 PM</div>
         <p>An introduction to creative AI, vibecoding, and requirements-driven software design. Your first hands-on taste of building with prompts.</p>
-        <a class="btn btn-navy" href="#reserve" data-ga="pp_reserve_june2">Reserve this night</a>
+        <a class="btn btn-navy" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-02" target="_blank" rel="noopener" data-ga="pp_reserve_june2">Reserve this night</a>
       </article>
 
       <article class="nite nite--teal r">
@@ -332,7 +332,7 @@ section { padding: 52px 0; }
         <h3>Fishing with AI</h3>
         <div class="nite-when"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>Tue, June 9, 2026 · 7–9 PM</div>
         <p>Exploring AI through storytelling, outdoor concepts, and real-world creative tools. Where curiosity meets the water.</p>
-        <a class="btn btn-navy" href="#reserve" data-ga="pp_reserve_june9">Reserve this night</a>
+        <a class="btn btn-navy" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-09" target="_blank" rel="noopener" data-ga="pp_reserve_june9">Reserve this night</a>
       </article>
 
       <article class="nite nite--gold r">
@@ -344,27 +344,26 @@ section { padding: 52px 0; }
         <h3>Prompt to Manufacturing</h3>
         <div class="nite-when"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>Tue, June 16, 2026 · 7–9 PM</div>
         <p>Turning prompts into physical products, prototypes, workflows, and production-ready ideas. From a sentence to something you can hold.</p>
-        <a class="btn btn-navy" href="#reserve" data-ga="pp_reserve_june16">Reserve this night</a>
+        <a class="btn btn-navy" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-16" target="_blank" rel="noopener" data-ga="pp_reserve_june16">Reserve this night</a>
       </article>
     </div>
   </div>
 </section>
 
-<!-- ============================================================ RESERVE / LUMA -->
+<!-- ============================================================ RESERVE / BOOKING -->
 <section id="reserve" class="reserve" data-ga-section="pp_reserve">
   <div class="wrap">
     <p class="eyebrow r" style="justify-content:center">Reserve your seat</p>
     <h2 class="sec-h2 r">Limited spots. Big possibilities.</h2>
-    <p class="sec-lead r">Pick the night (or nights) that fit. Checkout, calendar invites, and reminders are handled securely through Luma.</p>
+    <p class="sec-lead r">Pick the night (or nights) that fit and grab your seat — booking and checkout are handled by our host, Let's Play Studio.</p>
     <div class="r"><span class="seats"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Just 25 seats per night</span></div>
 
-    <div class="luma-embed r">
-      <iframe src="https://luma.com/embed/calendar/cal-IhEy5OHABrn4uQb/events"
-              width="600" height="450" frameborder="0"
-              allowfullscreen="" aria-hidden="false" tabindex="0"
-              title="Prompt Play — reserve your seat (registration by Luma)"></iframe>
+    <div class="book-row r">
+      <a class="btn btn-gold" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-02" target="_blank" rel="noopener" data-ga="pp_book_june2">June 2 · First Contact — $25</a>
+      <a class="btn btn-gold" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-09" target="_blank" rel="noopener" data-ga="pp_book_june9">June 9 · Fishing with AI — $50</a>
+      <a class="btn btn-gold" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-16" target="_blank" rel="noopener" data-ga="pp_book_june16">June 16 · Prompt to Manufacturing — $50</a>
     </div>
-    <p class="luma-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>Secure registration &amp; calendar invites by Luma</p>
+    <p class="book-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>Secure checkout via Let's Play Studio</p>
 
     <div class="reserve-actions r">
       <a class="btn btn-ghost" href="https://www.google.com/maps/dir/?api=1&destination=417+W+South+St,+Benton,+AR+72015" target="_blank" rel="noopener" data-ga="pp_directions">


### PR DESCRIPTION
## What this does

The Let's Play host moved registration from Luma to their own **ROLLER** system. This swaps the embedded Luma calendar on `/prompt-play` for direct, per-night ROLLER booking links.

## Changes (only `prompt-play/index.html`)
- **Removed** the Luma `<iframe>` embed and its supporting copy/styles.
- Each night now books through ROLLER (product `1965596`, filtered by date), opening in a new tab:
  | Night | Link |
  |-------|------|
  | June 2 · First Contact ($25) | `…/product/1965596?date=2026-06-02` |
  | June 9 · Fishing with AI ($50) | `…/product/1965596?date=2026-06-09` |
  | June 16 · Prompt to Manufacturing ($50) | `…/product/1965596?date=2026-06-16` |
- The Reserve section keeps its heading + "25 seats per night" badge + secondary actions (directions / share / email), but the embed is replaced by a three-button **"choose your night"** chooser (gold buttons → ROLLER). The three session cards' "Reserve this night" buttons also link directly to their date.
- Hero/header "Reserve" CTAs still anchor to `#reserve` (now the chooser).
- Copy updated to credit Let's Play Studio; Luma references and styles removed (renamed to `.book-row` / `.book-note`).
- Distinct analytics labels: `pp_book_june2/9/16` (chooser) vs `pp_reserve_june2/9/16` (cards).

## Verification
- [x] `grep -i luma` → 0 matches; `<iframe>` → 0
- [x] All 3 ROLLER URLs present with correct `date=` params (×2 each), all with `target="_blank" rel="noopener"`
- [x] HTML tag-balance OK; served locally and confirmed (no iframe, 6 ROLLER links)
- [ ] Live test booking after merge/deploy

https://claude.ai/code/session_01HUv59PNgawUc1sRre6My7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUv59PNgawUc1sRre6My7Z)_