### PR TITLE
[Feature] Prompt Play — social share image + June 2 time update

### DIFF
--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -15,7 +15,7 @@
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1122">
 <meta property="og:image:height" content="1402">
-<meta property="og:image:alt" content="Prompt Play — a creative AI workshop series at Let's Play Studio in Benton, AR. June 2, 9 and 16, 2026, 7–9 PM. Hosted by Corey Boelkens of Tale Waters &amp; Tides.">
+<meta property="og:image:alt" content="Prompt Play — a creative AI workshop series at Let's Play Studio in Benton, AR. June 2, 2026, 7:30–9:30 PM; June 9 and 16, 2026, 7–9 PM. Hosted by Corey Boelkens of Tale Waters &amp; Tides.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://talewatersandtides.com/assets/PromptPlayFB_Image.png">
 <link rel="canonical" href="https://talewatersandtides.com/prompt-play/">

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -10,6 +10,14 @@
 <meta property="og:description" content="Three nights. Three themes. Limitless possibilities. A grassroots creative-AI playground at Let's Play Studio, Benton AR — June 2, 9 &amp; 16, 2026.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://talewatersandtides.com/prompt-play/">
+<meta property="og:site_name" content="Tale Waters &amp; Tides">
+<meta property="og:image" content="https://talewatersandtides.com/assets/PromptPlayFB_Image.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1122">
+<meta property="og:image:height" content="1402">
+<meta property="og:image:alt" content="Prompt Play — a creative AI workshop series at Let's Play Studio in Benton, AR. June 2, 9 and 16, 2026, 7–9 PM. Hosted by Corey Boelkens of Tale Waters &amp; Tides.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://talewatersandtides.com/assets/PromptPlayFB_Image.png">
 <link rel="canonical" href="https://talewatersandtides.com/prompt-play/">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Prompt Play — A Creative AI Workshop Series | Tale Waters &amp; Tides</title>
-<meta name="description" content="Prompt Play is a 3-night creative AI workshop series at Let's Play Studio in Benton, AR — June 2, 9 &amp; 16, 2026, 7–9 PM CT. Not a class. Not a webinar. A creative playground for the curious. Limited to 25 seats per night.">
+<meta name="description" content="Prompt Play is a 3-night creative AI workshop series at Let's Play Studio in Benton, AR — June 2, 9 &amp; 16, 2026, 7:00–9:30 PM CT. Not a class. Not a webinar. A creative playground for the curious. Limited to 25 seats per night.">
 <meta name="theme-color" content="#0d1b2a">
 <meta property="og:title" content="Prompt Play — A Creative AI Workshop Series">
 <meta property="og:description" content="Three nights. Three themes. Limitless possibilities. A grassroots creative-AI playground at Let's Play Studio, Benton AR — June 2, 9 &amp; 16, 2026.">
@@ -258,7 +258,7 @@ section { padding: 52px 0; }
     <div class="hero-meta r">
       <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>Let's Play Studio · Benton, AR</span>
       <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>June 2, 9 &amp; 16, 2026</span>
-      <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>7:00–9:00 PM CT</span>
+      <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>7:00–9:30 PM CT</span>
     </div>
     <div class="hero-cta r">
       <a class="btn btn-gold" href="#reserve" data-ga="pp_hero_reserve">Reserve your seat</a>
@@ -326,7 +326,7 @@ section { padding: 52px 0; }
         </div>
         <div class="nite-num">Night 1</div>
         <h3>First Contact</h3>
-        <div class="nite-when"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>Tue, June 2, 2026 · 7–9 PM</div>
+        <div class="nite-when"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>Tue, June 2, 2026 · 7:30–9:30 PM</div>
         <p>An introduction to creative AI, vibecoding, and requirements-driven software design. Your first hands-on taste of building with prompts.</p>
         <a class="btn btn-navy" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-02" target="_blank" rel="noopener" data-ga="pp_reserve_june2">Reserve this night</a>
       </article>
@@ -432,7 +432,7 @@ section { padding: 52px 0; }
       <div class="where-aside">
         <div class="card r">
           <div class="lbl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>When</div>
-          <p>Three Tuesday evenings — June 2, 9 &amp; 16, 2026, from 7:00 to 9:00 PM Central.</p>
+          <p>Three Tuesday evenings — June 2 runs 7:30–9:30 PM; June 9 &amp; 16 run 7:00–9:00 PM (Central).</p>
         </div>
         <div class="card r">
           <div class="lbl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg>Good to know</div>


### PR DESCRIPTION
Two changes to `prompt-play/index.html` (per request, bundled in one PR).

## 1. Social / link-share image
Wires the uploaded **`PromptPlayFB_Image.png`** in as the share image so links shared to Facebook, iMessage, LinkedIn, etc. render the event graphic.
- Added `og:image` (+ `:type`, `:width` 1122, `:height` 1402, `:alt`), `og:site_name`, `twitter:card` = `summary_large_image`, `twitter:image`.

## 2. June 2 (First Contact) time → 7:30–9:30 PM
Night 1 now runs **7:30–9:30 PM**; June 9 & 16 stay 7:00–9:00 PM. Reviewed every time reference on the page:
- June 2 session card → **7:30–9:30 PM**
- "When" card → spells out per-night: "June 2 runs 7:30–9:30 PM; June 9 & 16 run 7:00–9:00 PM (Central)"
- Hero chip + meta description → widened to the **7:00–9:30 PM CT** envelope so no blanket line misstates the new start
- June 9 / June 16 cards unchanged

## Verification
- [x] Page + `og:image` asset serve 200 (`image/png`, exact case path); wrong case → 404
- [x] No stale "7:00–9:00 PM CT"; June 2 = 7:30–9:30 in both the card and the When card; June 9/16 unchanged
- [x] HTML tag-balance OK

## Heads-up (outside this PR)
The **share graphic** and the **printed poster/QR poster** still show **7:00–9:00 PM** for all nights — only the webpage text reflects June 2's new 7:30 start. Also confirm the **ROLLER** product for the June 2 date shows 7:30 PM. Happy to help refresh the graphic if useful.

https://claude.ai/code/session_01HUv59PNgawUc1sRre6My7Z