### PR TITLE
[Feature] Prompt Play — Hey, Let's Play partnership branding

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -168,7 +168,7 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; 
           <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>June 2, 9 &amp; 16, 2026</span>
           <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>Benton, AR</span>
         </div>
-        <div class="ev-d">Three nights, three themes. A grassroots playground where AI meets creativity, curiosity, and community — vibecoding, storytelling, and prompt-to-product, hosted at Let's Play Studio. Not a class. Not a webinar.</div>
+        <div class="ev-d">Three nights, three themes. A grassroots playground where AI meets creativity, curiosity, and community — vibecoding, storytelling, and prompt-to-product, in partnership with Hey, Let's Play. Not a class. Not a webinar.</div>
         <div class="ev-q">View the series &amp; reserve your seat →</div>
       </a>
 

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -436,7 +436,7 @@ section { padding: 52px 0; }
 
     <div class="venue-gallery r">
       <img src="/assets/OutdoorFrontage.webp" alt="The Hey, Let's Play storefront in Benton, AR with its neon sign lit at dusk" loading="lazy" decoding="async">
-      <img src="/assets/Thinking%20Space.webp" alt="Inside Hey, Let's Play — a bright, open lounge with comfortable seating set up for creating together" loading="lazy" decoding="async">
+      <img src="/assets/thinking-space.webp" alt="Inside Hey, Let's Play — a bright, open lounge with comfortable seating set up for creating together" loading="lazy" decoding="async">
       <img src="/assets/Beverages.webp" alt="A fresh coffee at Hey, Let's Play — coffee is on us every Prompt Play night" loading="lazy" decoding="async">
     </div>
 

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -4,10 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Prompt Play — A Creative AI Workshop Series | Tale Waters &amp; Tides</title>
-<meta name="description" content="Prompt Play is a 3-night creative AI workshop series at Let's Play Studio in Benton, AR — June 2, 9 &amp; 16, 2026, 7:00–9:30 PM CT. Not a class. Not a webinar. A creative playground for the curious. Limited to 25 seats per night.">
+<meta name="description" content="Prompt Play is a 3-night creative AI workshop series at Hey, Let's Play in Benton, AR — June 2, 9 &amp; 16, 2026, 7:00–9:30 PM CT. Not a class. Not a webinar. A creative playground for the curious. Limited to 25 seats per night.">
 <meta name="theme-color" content="#0d1b2a">
 <meta property="og:title" content="Prompt Play — A Creative AI Workshop Series">
-<meta property="og:description" content="Three nights. Three themes. Limitless possibilities. A grassroots creative-AI playground at Let's Play Studio, Benton AR — June 2, 9 &amp; 16, 2026.">
+<meta property="og:description" content="Three nights. Three themes. Limitless possibilities. A grassroots creative-AI playground at Hey, Let's Play, Benton AR — June 2, 9 &amp; 16, 2026.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://talewatersandtides.com/prompt-play/">
 <meta property="og:site_name" content="Tale Waters &amp; Tides">
@@ -15,7 +15,7 @@
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1122">
 <meta property="og:image:height" content="1402">
-<meta property="og:image:alt" content="Prompt Play — a creative AI workshop series at Let's Play Studio in Benton, AR. June 2, 2026, 7:30–9:30 PM; June 9 and 16, 2026, 7–9 PM. Hosted by Corey Boelkens of Tale Waters &amp; Tides.">
+<meta property="og:image:alt" content="Prompt Play — a creative AI workshop series at Hey, Let's Play in Benton, AR. June 2, 2026, 7:30–9:30 PM; June 9 and 16, 2026, 7–9 PM. Hosted by Corey Boelkens of Tale Waters &amp; Tides.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://talewatersandtides.com/assets/PromptPlayFB_Image.png">
 <link rel="canonical" href="https://talewatersandtides.com/prompt-play/">
@@ -196,6 +196,12 @@ section { padding: 52px 0; }
 .where-aside .card p { font-size: .92rem; color: var(--muted); }
 .where-aside .card .lbl { font-family: var(--fd); font-weight: 600; color: var(--navy); display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
 .where-aside .card .lbl svg { width: 18px; height: 18px; color: var(--coral); }
+.partner { display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; margin: 26px auto 4px; }
+.partner-lbl { font-family: var(--fb); font-weight: 600; letter-spacing: .14em; text-transform: uppercase; font-size: .72rem; color: var(--muted); }
+.partner-logo { height: 76px; width: auto; background: #fff; border: 1px solid var(--line); border-radius: 14px; padding: 10px 16px; box-shadow: 0 6px 20px rgba(20,50,74,.07); }
+.venue-gallery { display: grid; grid-template-columns: 1fr; gap: 14px; margin: 26px 0 4px; }
+@media(min-width: 680px) { .venue-gallery { grid-template-columns: repeat(3, 1fr); } }
+.venue-gallery img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; border-radius: 16px; border: 1px solid var(--line); box-shadow: 0 8px 26px rgba(20,50,74,.08); display: block; }
 
 /* ============================================================ HOST */
 .host { text-align: center; }
@@ -256,7 +262,7 @@ section { padding: 52px 0; }
     <div class="r"><span class="series-pill">A Creative AI Workshop Series</span></div>
     <p class="hero-lead r">Three nights. Three themes. Limitless possibilities. Join us for a grassroots MVP experiment where <b>AI meets creativity, curiosity, and community.</b></p>
     <div class="hero-meta r">
-      <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>Let's Play Studio · Benton, AR</span>
+      <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>Hey, Let's Play · Benton, AR</span>
       <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>June 2, 9 &amp; 16, 2026</span>
       <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>7:00–9:30 PM CT</span>
     </div>
@@ -363,7 +369,7 @@ section { padding: 52px 0; }
   <div class="wrap">
     <p class="eyebrow r" style="justify-content:center">Reserve your seat</p>
     <h2 class="sec-h2 r">Limited spots. Big possibilities.</h2>
-    <p class="sec-lead r">Pick the night (or nights) that fit and grab your seat — booking and checkout are handled by our host, Let's Play Studio.</p>
+    <p class="sec-lead r">Pick the night (or nights) that fit and grab your seat — booking and checkout are handled by our partner, Hey, Let's Play.</p>
     <div class="r"><span class="seats"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Just 25 seats per night</span></div>
 
     <div class="book-row r">
@@ -371,7 +377,7 @@ section { padding: 52px 0; }
       <a class="btn btn-gold" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-09" target="_blank" rel="noopener" data-ga="pp_book_june9">June 9 · Fishing with AI — $50</a>
       <a class="btn btn-gold" href="https://ecom.roller.app/playdate/booknow/en-us/product/1965596?date=2026-06-16" target="_blank" rel="noopener" data-ga="pp_book_june16">June 16 · Prompt to Manufacturing — $50</a>
     </div>
-    <p class="book-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>Secure checkout via Let's Play Studio</p>
+    <p class="book-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>Secure checkout via Hey, Let's Play</p>
 
     <div class="reserve-actions r">
       <a class="btn btn-ghost" href="https://www.google.com/maps/dir/?api=1&destination=417+W+South+St,+Benton,+AR+72015" target="_blank" rel="noopener" data-ga="pp_directions">
@@ -419,12 +425,27 @@ section { padding: 52px 0; }
 <!-- ============================================================ WHERE -->
 <section class="what" data-ga-section="pp_where">
   <div class="wrap">
+    <p class="eyebrow r">The space</p>
+    <h2 class="sec-h2 r">Where it all happens</h2>
+    <p class="sec-lead r">Prompt Play is hosted in partnership with <strong>Hey, Let's Play</strong> — a bright creative community space in Benton, AR for curious minds, families, and builders.</p>
+
+    <div class="partner r">
+      <span class="partner-lbl">In partnership with</span>
+      <img class="partner-logo" src="/assets/LetsPlayLogo.jpg" alt="Hey, Let's Play logo" loading="lazy" decoding="async">
+    </div>
+
+    <div class="venue-gallery r">
+      <img src="/assets/OutdoorFrontage.webp" alt="The Hey, Let's Play storefront in Benton, AR with its neon sign lit at dusk" loading="lazy" decoding="async">
+      <img src="/assets/Thinking%20Space.webp" alt="Inside Hey, Let's Play — a bright, open lounge with comfortable seating set up for creating together" loading="lazy" decoding="async">
+      <img src="/assets/Beverages.webp" alt="A fresh coffee at Hey, Let's Play — coffee is on us every Prompt Play night" loading="lazy" decoding="async">
+    </div>
+
     <div class="where-grid">
       <div class="where-card r">
-        <p class="eyebrow">Where</p>
-        <h3>Let's Play Studio</h3>
+        <p class="eyebrow">Find us</p>
+        <h3>Hey, Let's Play</h3>
         <p class="addr"><a href="https://www.google.com/maps/search/?api=1&query=417+W+South+St,+Benton,+AR+72015" target="_blank" rel="noopener" data-ga="pp_where_map">417 W South St, Benton, AR 72015</a></p>
-        <p>A creative community space for curious minds, families, and builders. Huge thanks to Let's Play for sponsoring this grassroots experiment — a place to create, a community to grow, a future to build.</p>
+        <p>Our partner Hey, Let's Play is a creative community space for curious minds, families, and builders. Huge thanks to them for making this grassroots experiment possible — a place to create, a community to grow, a future to build.</p>
         <a class="btn btn-gold" href="https://www.google.com/maps/dir/?api=1&destination=417+W+South+St,+Benton,+AR+72015" target="_blank" rel="noopener" data-ga="pp_where_directions">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 12-9 12s-9-5-9-12a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>Get directions
         </a>
@@ -496,7 +517,7 @@ section { padding: 52px 0; }
   var shareBtn = document.getElementById('shareBtn');
   var shareLabel = document.getElementById('shareLabel');
   var url = 'https://talewatersandtides.com/prompt-play/';
-  var shareData = { title: 'Prompt Play — A Creative AI Workshop Series', text: "3 nights of creative AI at Let's Play Studio in Benton, AR. Come build something.", url: url };
+  var shareData = { title: 'Prompt Play — A Creative AI Workshop Series', text: "3 nights of creative AI at Hey, Let's Play in Benton, AR. Come build something.", url: url };
   shareBtn.addEventListener('click', function(){
     if (navigator.share) { navigator.share(shareData).catch(function(){}); }
     else if (navigator.clipboard) { navigator.clipboard.writeText(url).then(function(){ shareLabel.textContent = 'Link copied!'; setTimeout(function(){ shareLabel.textContent = 'Share with a friend'; }, 2200); }).catch(function(){ window.prompt('Copy this link:', url); }); }

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -436,7 +436,7 @@ section { padding: 52px 0; }
 
     <div class="venue-gallery r">
       <img src="/assets/OutdoorFrontage.webp" alt="The Hey, Let's Play storefront in Benton, AR with its neon sign lit at dusk" loading="lazy" decoding="async">
-      <img src="/assets/thinking-space.webp" alt="Inside Hey, Let's Play — a bright, open lounge with comfortable seating set up for creating together" loading="lazy" decoding="async">
+      <img src="/assets/Thinking%20Space.webp" alt="Inside Hey, Let's Play — a bright, open lounge with comfortable seating set up for creating together" loading="lazy" decoding="async">
       <img src="/assets/Beverages.webp" alt="A fresh coffee at Hey, Let's Play — coffee is on us every Prompt Play night" loading="lazy" decoding="async">
     </div>
 


### PR DESCRIPTION
## What this does

Reframes the venue as our **partner, "Hey, Let's Play"** (previously written as "Let's Play Studio") across the Prompt Play page, and brings in their logo + venue photos per best practice.

## Changes
**`prompt-play/index.html`**
- **Copy/meta rebrand:** every "Let's Play Studio" / "host" / "sponsoring" reference → **"Hey, Let's Play"**, framed as a *partnership* (hero location line, meta description, OG/Twitter description + alt, booking lead + note, share text, and the Where card). "Host" now refers only to Corey (the workshop host); Hey, Let's Play is the venue partner.
- **Where section rebuilt** with:
  - A heading + "**In partnership with**" **logo lockup** (`LetsPlayLogo.jpg` on a white card so the logo's white background blends on the cream page).
  - A responsive **venue photo gallery** — storefront (`OutdoorFrontage.webp`), interior (`Thinking Space.webp`), and coffee (`Beverages.webp`) — normalized to a 4:3 grid with rounded corners, lazy-loaded, with descriptive alt text.
  - Venue card updated to "Hey, Let's Play" with partnership copy; address / directions / "When" / "Good to know" unchanged.

**`events/index.html`**
- Events hub card now reads "in partnership with Hey, Let's Play" (was "hosted at Let's Play Studio").

## Asset / UX notes (best practice)
- The logo is a **white-background JPG**, so it's seated on a white rounded card rather than placed raw on the cream background.
- `Thinking Space.webp` contains a space in its filename; referenced URL-encoded as `Thinking%20Space.webp` (verified it resolves). If you'd prefer, I can rename it to remove the space.
- Partner logo is a credit, so it's **not linked** (no canonical Hey, Let's Play site URL on hand). Happy to link it if you have one.

## Verification
- [x] No "Let's Play Studio" remains; "Hey, Let's Play" used consistently (incl. events hub)
- [x] Page + all four new assets serve 200 (`image/jpeg` + `image/webp`), including the `%20` path
- [x] HTML tag-balance OK on both files
- [ ] Visual QA on device (gallery crops, logo card) after deploy

https://claude.ai/code/session_01HUv59PNgawUc1sRre6My7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUv59PNgawUc1sRre6My7Z)_