### PR TITLE
[Bug] Fix mobile layout/overflow on First Contact facilitator dashboard

### DIFF
--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -17,7 +17,7 @@
   --fd: 'Fredoka', system-ui, sans-serif; --fb: 'DM Sans', system-ui, sans-serif; --mw: 1080px;
 }
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: var(--cream); color: var(--ink); font-family: var(--fb); font-size: 1rem; line-height: 1.6; -webkit-font-smoothing: antialiased; overflow-x: hidden; }
+body { background: var(--cream); color: var(--ink); font-family: var(--fb); font-size: 1rem; line-height: 1.6; -webkit-font-smoothing: antialiased; overflow-x: clip; }
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 18px; }
 h1, h2, h3, h4 { font-family: var(--fd); color: var(--navy); line-height: 1.15; }
 a { color: var(--teal); }

--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -17,7 +17,7 @@
   --fd: 'Fredoka', system-ui, sans-serif; --fb: 'DM Sans', system-ui, sans-serif; --mw: 1080px;
 }
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: var(--cream); color: var(--ink); font-family: var(--fb); font-size: 1rem; line-height: 1.6; -webkit-font-smoothing: antialiased; }
+body { background: var(--cream); color: var(--ink); font-family: var(--fb); font-size: 1rem; line-height: 1.6; -webkit-font-smoothing: antialiased; overflow-x: hidden; }
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 18px; }
 h1, h2, h3, h4 { font-family: var(--fd); color: var(--navy); line-height: 1.15; }
 a { color: var(--teal); }
@@ -49,7 +49,7 @@ main { padding: 24px 0 60px; }
 
 .gate { max-width: 440px; margin: 8vh auto 0; }
 .card { background: var(--cream-2); border: 1px solid var(--line); border-radius: 16px; padding: 22px; box-shadow: 0 8px 26px rgba(20,50,74,.05); }
-.card > h3 { font-size: 1.05rem; margin-bottom: 12px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.card > h3 { font-size: 1.05rem; margin-bottom: 12px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px; }
 .card .cnt { font-family: var(--fd); font-weight: 700; color: var(--teal); font-size: .9rem; }
 
 .eyebrow { font-family: var(--fb); font-weight: 600; font-size: .68rem; letter-spacing: .2em; text-transform: uppercase; color: var(--coral); margin-bottom: 8px; }
@@ -60,7 +60,8 @@ main { padding: 24px 0 60px; }
 .grid { display: grid; grid-template-columns: 1fr; gap: 16px; }
 @media(min-width: 680px) { .grid { grid-template-columns: 1fr 1fr; } .grid .span2 { grid-column: 1 / -1; } }
 
-.stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.stats { display: grid; grid-template-columns: 1fr; gap: 12px; }
+@media(min-width: 480px) { .stats { grid-template-columns: repeat(3, 1fr); } }
 .stat { background: var(--cream-2); border: 1px solid var(--line); border-radius: 14px; padding: 16px; text-align: center; }
 .stat .n { font-family: var(--fd); font-weight: 700; color: var(--navy); font-size: 1.8rem; line-height: 1; }
 .stat .l { font-size: .76rem; color: var(--muted); margin-top: 4px; }


### PR DESCRIPTION
## Problem

The facilitator dashboard (`first-contact/facilitator/index.html`, live at https://talewatersandtides.com/first-contact/facilitator/) renders poorly on phones — some sections crowd or push the page sideways.

**Root cause:** the page was built without the responsive conventions its two sibling First Contact pages already follow. `first-contact/index.html` and `first-contact/dashboard/index.html` both carry a horizontal-overflow safety net, `flex-wrap: wrap` on flex headers, and mobile-first grids. The facilitator page had none of these.

## Fixes (CSS-only, single file)

1. **Overflow safety net** — add `overflow-x: clip` to `body` so no overflowing child can scroll the whole page sideways.
   - _Deviation from siblings:_ the two sibling pages use `overflow-x: hidden`. This page uses `overflow-x: clip` instead because the facilitator header (`.hd`) is `position: sticky; top: 0`, and `overflow-x: hidden` on `body` can establish a scroll container that breaks sticky positioning in some browsers. `clip` prevents the same horizontal overflow without creating a scroll container, so the sticky header keeps working. (Raised by Gemini review; applied in 12901f4.)
2. **Wrapping card headers** — add `flex-wrap: wrap` to `.card > h3`. The Roster header (`Roster` + count + **Clear all test data** button with `margin-left:auto`) and the Leads header (`Leads` + **Export CSV** button) now drop their action button onto a second line instead of overflowing / crushing the title on narrow screens.
3. **Mobile-first stat row** — `.stats` now defaults to a single column and goes 3-across at `≥480px`, instead of being locked to `repeat(3, 1fr)` at every width (which crammed the three KPI tiles to ~70px on a phone).

## Sibling audit

Per request, also re-audited `first-contact/index.html` and `first-contact/dashboard/index.html` for mobile overflow. Both already have the responsive conventions and showed no fixed-width / nowrap / unconstrained-image overflow sources — **no changes needed**. (They could optionally adopt `overflow-x: clip` too for the same sticky-header robustness, but that's out of scope here.)

## Verification

- Static review of the diff against sibling conventions.
- Audited siblings for overflow culprits (fixed wide widths, `white-space: nowrap` on long content, unconstrained images, tables without scroll wrappers) — clean.
- Recommended manual check: open the page in browser responsive devtools at 320 / 360 / 390px and confirm (a) no sideways scroll, (b) action buttons wrap under their titles, (c) stat tiles stack to one column on phones and go 3-across at ≥480px, (d) the header stays pinned while scrolling. The dashboard sits behind Supabase magic-link auth, so the gate/sign-in card is what renders without login; to inspect the dashboard layout, temporarily un-hide `#dash` in devtools.

https://claude.ai/code/session_013eM7Vxd6TP57gSYFNBtwta