### PR TITLE
[Bug] Fix right-edge overflow gap on facilitator dashboard (iOS)

### DIFF
--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -17,6 +17,7 @@
   --fd: 'Fredoka', system-ui, sans-serif; --fb: 'DM Sans', system-ui, sans-serif; --mw: 1080px;
 }
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+html { overflow-x: clip; }
 body { background: var(--cream); color: var(--ink); font-family: var(--fb); font-size: 1rem; line-height: 1.6; -webkit-font-smoothing: antialiased; overflow-x: clip; }
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 18px; }
 h1, h2, h3, h4 { font-family: var(--fd); color: var(--navy); line-height: 1.15; }


### PR DESCRIPTION
## Problem

Follow-up to #31. On a real iPhone (iOS 26 / Safari), the First Contact facilitator dashboard still shows a vertical strip of empty space down the **right edge** — the signature of the document being a few pixels wider than the viewport (horizontal overflow). The merged responsive layout is live (KPI stats stack to one column), but the gap remained.

## Root cause

#31 placed the overflow guard as `overflow-x: clip` on the **`<body>`** element. A `<body>`-level overflow value only suppresses document-level scrolling if the browser *propagates* it to the viewport. WebKit/Safari reliably propagates `overflow: hidden` (which is why the two sibling pages, which use `hidden` on `body`, don't show this gap) but does **not** reliably propagate the newer `overflow: clip` from `body` to the viewport. So the viewport stayed horizontally scrollable and a slightly-too-wide descendant produced the right-edge gap.

We intentionally used `clip` (not `hidden`) on `body` in #31 to avoid making `body` a scroll container between the sticky header (`.hd`) and the viewport.

## Fix (CSS-only, one line)

Add `html { overflow-x: clip; }` so the **root/viewport** clips horizontal overflow directly instead of relying on body→viewport propagation. Clipping the x-axis on the root doesn't establish a vertical scroll container and doesn't affect `position: sticky` (a y-axis behavior), so the sticky header keeps working. The existing `body` rule is left in place.

## Scope

- Single file: `first-contact/facilitator/index.html`.
- **Siblings unaffected:** `first-contact/index.html` and `first-contact/dashboard/index.html` use `overflow-x: hidden` on `body` (propagates correctly), so they don't have this gap — no changes there.
- The exact element overflowing by a few px isn't pinpointed (data tables are already wrapped in `.tbl-wrap { overflow:auto }`; the screenshot showed empty data, so the source is small/structural). The root-level clip contains it regardless — this is the correct guard, not just masking.

## Verification

After deploy, hard-reload the page on an iPhone and confirm: no empty strip on the right edge, symmetric left/right margins, no horizontal rubber-band, header still pinned while scrolling, and stats still stack on phone / 3-across on wider screens.

https://claude.ai/code/session_013eM7Vxd6TP57gSYFNBtwta

---
_Generated by [Claude Code](https://claude.ai/code/session_013eM7Vxd6TP57gSYFNBtwta)_