### PR TITLE
[UX] Bigger TWT logo in nav, header, and footer

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -54,8 +54,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 @media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 26px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 30px; } }
+.nv-brand img { height: 40px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 44px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -134,7 +134,7 @@ section { padding: 24px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 22px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/first-contact/dashboard/index.html
+++ b/first-contact/dashboard/index.html
@@ -61,8 +61,8 @@ a { color: var(--navy); }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 @media(min-width: 768px) { .hd-in { padding: 0 32px; min-height: 66px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: .82rem; letter-spacing: .12em; text-transform: uppercase; color: var(--navy); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 24px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 28px; } }
+.hd-brand img { height: 34px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 40px; } }
 .hd-r { display: flex; align-items: center; gap: 8px; }
 
 /* ===== BUTTONS ===== */

--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -28,8 +28,8 @@ a { color: var(--teal); }
 .hd { background: var(--navy-deep); color: var(--cream); position: sticky; top: 0; z-index: 50; }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 12px 18px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .hd-brand { font-family: var(--fb); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; font-size: .8rem; color: var(--cream); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 24px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 28px; } }
+.hd-brand img { height: 30px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 34px; } }
 .hd-brand b { color: var(--gold); }
 
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: .95rem; text-decoration: none; border-radius: 999px; padding: 10px 20px; min-height: 44px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s; }

--- a/first-contact/index.html
+++ b/first-contact/index.html
@@ -76,8 +76,8 @@ a { color: var(--navy); }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 @media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 28px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 32px; } }
+.hd-brand img { height: 42px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 48px; } }
 
 /* ============================================================ BUTTONS */
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: 1rem; text-decoration: none; border-radius: 999px; padding: 13px 26px; min-height: 48px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s, color .2s, border-color .2s; }

--- a/index.html
+++ b/index.html
@@ -104,8 +104,8 @@ body {
   display: inline-flex;
   align-items: center;
 }
-.nv-brand img { height: 26px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 30px; } }
+.nv-brand img { height: 40px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 44px; } }
 
 .nv-r {
   display: flex;
@@ -606,7 +606,7 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
   letter-spacing: .14em; text-transform: uppercase; color: var(--dm);
   display: inline-flex; align-items: center;
 }
-.ft-br img { height: 22px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a {
   color: var(--dm); text-decoration: none;

--- a/projects/buffalo-river/index.html
+++ b/projects/buffalo-river/index.html
@@ -55,8 +55,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 @media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 26px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 30px; } }
+.nv-brand img { height: 40px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 44px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -160,7 +160,7 @@ section { padding: 28px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 22px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/projects/index.html
+++ b/projects/index.html
@@ -54,8 +54,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 @media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 26px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 30px; } }
+.nv-brand img { height: 40px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 44px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -134,7 +134,7 @@ section { padding: 24px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 22px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -79,8 +79,8 @@ a { color: var(--navy); }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 @media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 28px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 32px; } }
+.hd-brand img { height: 42px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 48px; } }
 
 /* ============================================================ BUTTONS */
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: 1rem; text-decoration: none; border-radius: 999px; padding: 13px 26px; min-height: 48px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s, color .2s, border-color .2s; }

--- a/prompt-play/kit/index.html
+++ b/prompt-play/kit/index.html
@@ -80,8 +80,8 @@ a { color: var(--navy); }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 @media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 24px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 28px; } }
+.hd-brand img { height: 34px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 40px; } }
 .hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .hd-brand .tt b { font-weight: 600; }
 


### PR DESCRIPTION
## Summary

The TWT logo shipped in #35 renders too small — the horizontal lockup (whale-tail mark + "Tale Waters and Tides" wordmark) sits at only ~46–50% of the nav height across every page, which makes it read as a tiny icon rather than as a brand. Both screenshots the user shared (`talewatersandtides.com` and `/prompt-play/`) showed the same issue.

This PR is **CSS-only** — no markup, no asset, no behavior changes. The logo height is bumped to ~70% of the nav/header height (the ratio most modern marketing sites use), with the container heights left untouched so nothing cascades into hero padding, `scroll-padding-top`, or the mobile menu's `top` offset.

## Resize map

| Surface | Mobile (was → new) | Desktop (was → new) | Container |
|---|---|---|---|
| Dark nav `.nv-brand img` (`index.html`, `events/`, `projects/`, `projects/buffalo-river/`) | 26 → **40 px** | 30 → **44 px** | 56 / 60 px |
| Cream header `.hd-brand img` logo-only (`prompt-play/`, `first-contact/`) | 28 → **42 px** | 32 → **48 px** | 60 / 68 px |
| Cream header `.hd-brand img` with page label (`prompt-play/kit/`, `first-contact/dashboard/`) | 24 → **34 px** | 28 → **40 px** | 60 / 68 px |
| Dark header `.hd-brand img` with "· Facilitator" label (`first-contact/facilitator/`) | 24 → **30 px** | 28 → **34 px** | compact sticky |
| Dark footer `.ft-br img` (`index.html`, `events/`, `projects/`, `projects/buffalo-river/`) | 22 → **32 px** | (same) | flex row |

Pages with text labels next to the logo get a slightly smaller logo than the logo-only pages so the page-label span ("· Kit", "· Dashboard", "· Facilitator") still sits on the same row without wrapping.

`/projects/quest/` (Holy Grail custom theme) and `/quest/` (redirect page) intentionally untouched — same as #35.

## Mobile fit sanity

iPhone SE (320 px viewport), dark nav math: 16 px padding × 2 + 40 px logo (~60 px wide at 3:2) + 44 px hamburger + 8 px gaps ≈ 172 px content → ~148 px slack. No overflow risk.

## Test plan

- [ ] Open the GitHub Pages deploy preview at desktop (≥1024 px) and a mobile viewport (~360 px).
- [ ] Confirm the logo on each of the 9 standard pages (main, events, projects, buffalo-river, prompt-play, prompt-play/kit, first-contact, first-contact/dashboard, first-contact/facilitator) is clearly larger and the wordmark portion is legible without zoom.
- [ ] On the cream pages with a CTA button (Reserve a seat / Copy for your AI / Check in), confirm the button still sits on the same row as the logo.
- [ ] On `prompt-play/kit/`, `first-contact/dashboard/`, `first-contact/facilitator/`: confirm the "· Kit" / "· Dashboard" / "· Facilitator" page label stays on the same line as the logo.
- [ ] On the dark mobile nav: confirm the hamburger button doesn't collide with the logo and nothing overflows the viewport horizontally.
- [ ] Scroll to the footer on dark pages — the logo should feel like a brand sign-off, not a watermark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkXmcp4ATxNJBRZFt9xBzg)_