### PR TITLE
[UX] 72px header logo with 96px nav — bold brand mark

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -43,7 +43,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 64px; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-size: 1.0625rem; line-height: 1.65; overflow-x: hidden; }
 
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 20px; }
@@ -51,11 +51,11 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 
 /* NAV */
 .nv { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: rgba(13,27,42,.92); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-bottom: 1px solid var(--bd); }
-.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
+.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 96px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 40px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 44px; } }
+.nv-brand img { height: 72px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 72px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -70,7 +70,7 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .hm.on span:nth-child(3) { transform: rotate(-45deg) translate(4.5px,-4.5px); }
 @media(min-width: 768px) { .hm { display: none; } .nv-desk { display: flex; } }
 
-.mn { position: fixed; top: 56px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
+.mn { position: fixed; top: 96px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
 .mn.on { display: flex; }
 .mn a { font-size: 1.125rem; color: var(--tx); text-decoration: none; padding: 18px 0; border-bottom: 1px solid var(--bd); display: flex; justify-content: space-between; align-items: center; }
 .mn a.cur { color: var(--gd); }
@@ -81,8 +81,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .mn-pfg-s { font-size: 0.75rem; color: var(--dm); margin-top: 3px; }
 
 /* PAGE HEADER */
-.ph { padding: 96px 0 24px; }
-@media(min-width: 768px) { .ph { padding: 120px 0 36px; } }
+.ph { padding: 120px 0 24px; }
+@media(min-width: 768px) { .ph { padding: 140px 0 36px; } }
 .ph .lb { font-size: 0.6875rem; letter-spacing: .2em; text-transform: uppercase; color: var(--gd); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
 .ph .lb::before { content: ''; width: 20px; height: 1px; background: var(--gd); }
 .ph h1 { font-family: var(--fd); font-size: clamp(1.75rem, 5vw, 2.75rem); font-weight: 400; line-height: 1.15; color: var(--cr); margin-bottom: 16px; max-width: 760px; }
@@ -134,7 +134,7 @@ section { padding: 24px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 48px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/first-contact/dashboard/index.html
+++ b/first-contact/dashboard/index.html
@@ -63,8 +63,8 @@ a { color: var(--navy); }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: .82rem; letter-spacing: .12em; text-transform: uppercase; color: var(--navy); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
 .hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
 @media(min-width: 768px) { .hd-brand img { height: 72px; } }
-.hd-brand span { display: none; }
-@media(min-width: 768px) { .hd-brand span { display: inline; } }
+.hd-brand span { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+@media(min-width: 768px) { .hd-brand span { position: static; width: auto; height: auto; overflow: visible; clip: auto; white-space: inherit; } }
 .hd-r { display: flex; align-items: center; gap: 8px; }
 
 /* ===== BUTTONS ===== */

--- a/first-contact/dashboard/index.html
+++ b/first-contact/dashboard/index.html
@@ -37,7 +37,7 @@
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 /* Bigger, more readable base — every rem scales from here. */
-html { font-size: 112.5%; scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 72px; }
+html { font-size: 112.5%; scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body {
   background: var(--cream);
   color: var(--ink);
@@ -58,11 +58,13 @@ a { color: var(--navy); }
 
 /* ===== HEADER ===== */
 .hd { position: sticky; top: 0; z-index: 60; background: rgba(247,241,227,.92); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-bottom: 1px solid var(--line); }
-.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-@media(min-width: 768px) { .hd-in { padding: 0 32px; min-height: 66px; } }
+.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+@media(min-width: 768px) { .hd-in { padding: 0 32px; min-height: 96px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: .82rem; letter-spacing: .12em; text-transform: uppercase; color: var(--navy); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 34px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 40px; } }
+.hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 72px; } }
+.hd-brand span { display: none; }
+@media(min-width: 768px) { .hd-brand span { display: inline; } }
 .hd-r { display: flex; align-items: center; gap: 8px; }
 
 /* ===== BUTTONS ===== */

--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -28,8 +28,10 @@ a { color: var(--teal); }
 .hd { background: var(--navy-deep); color: var(--cream); position: sticky; top: 0; z-index: 50; }
 .hd-in { max-width: var(--mw); margin: 0 auto; padding: 12px 18px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .hd-brand { font-family: var(--fb); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; font-size: .8rem; color: var(--cream); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 30px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 34px; } }
+.hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 72px; } }
+.hd-brand span { display: none; }
+@media(min-width: 768px) { .hd-brand span { display: inline; } }
 .hd-brand b { color: var(--gold); }
 
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: .95rem; text-decoration: none; border-radius: 999px; padding: 10px 20px; min-height: 44px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s; }

--- a/first-contact/facilitator/index.html
+++ b/first-contact/facilitator/index.html
@@ -30,8 +30,8 @@ a { color: var(--teal); }
 .hd-brand { font-family: var(--fb); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; font-size: .8rem; color: var(--cream); text-decoration: none; display: inline-flex; align-items: center; gap: 9px; }
 .hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
 @media(min-width: 768px) { .hd-brand img { height: 72px; } }
-.hd-brand span { display: none; }
-@media(min-width: 768px) { .hd-brand span { display: inline; } }
+.hd-brand span { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+@media(min-width: 768px) { .hd-brand span { position: static; width: auto; height: auto; overflow: visible; clip: auto; white-space: inherit; } }
 .hd-brand b { color: var(--gold); }
 
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: .95rem; text-decoration: none; border-radius: 999px; padding: 10px 20px; min-height: 44px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s; }

--- a/first-contact/index.html
+++ b/first-contact/index.html
@@ -44,7 +44,7 @@
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 /* Bump the base ~6% so body copy reads a touch larger everywhere (rem-based, so it scales the whole page proportionally). */
-html { font-size: 106.25%; scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 76px; }
+html { font-size: 106.25%; scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body {
   background: var(--cream);
   color: var(--ink);
@@ -73,11 +73,11 @@ a { color: var(--navy); }
   border-bottom: 1px solid transparent; transition: border-color .3s, background .3s;
 }
 .hd.solid { border-bottom-color: var(--line); background: rgba(247,241,227,.95); }
-.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-@media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
+.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+@media(min-width: 768px) { .hd-in { padding: 0 40px; min-height: 96px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 42px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 48px; } }
+.hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 72px; } }
 
 /* ============================================================ BUTTONS */
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: 1rem; text-decoration: none; border-radius: 999px; padding: 13px 26px; min-height: 48px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s, color .2s, border-color .2s; }
@@ -106,8 +106,8 @@ section { padding: 46px 0; }
 .r.v { opacity: 1; transform: translateY(0); }
 
 /* ============================================================ HERO */
-.hero { padding: 104px 0 36px; text-align: center; position: relative; }
-@media(min-width: 768px) { .hero { padding: 132px 0 52px; } }
+.hero { padding: 136px 0 36px; text-align: center; position: relative; }
+@media(min-width: 768px) { .hero { padding: 156px 0 52px; } }
 .hero-tag { font-family: var(--fb); font-weight: 600; font-size: clamp(.72rem, 2.4vw, .95rem); letter-spacing: .26em; text-transform: uppercase; color: var(--navy); opacity: .85; }
 .wordmark { margin: 8px auto 6px; line-height: .86; font-size: inherit; font-weight: inherit; }
 .wm-1 { display: block; font-family: var(--fd); font-weight: 700; color: var(--navy); font-size: clamp(3rem, 15vw, 7.5rem); letter-spacing: -.02em; }

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 html {
   scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
-  scroll-padding-top: 64px;
+  scroll-padding-top: 100px;
 }
 
 body {
@@ -83,13 +83,13 @@ body {
   max-width: var(--mw);
   margin: 0 auto;
   padding: 0 16px;
-  height: 56px;
+  height: 96px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
-@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
+@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 96px; } }
 
 .nv-brand {
   font-family: var(--fd);
@@ -104,8 +104,8 @@ body {
   display: inline-flex;
   align-items: center;
 }
-.nv-brand img { height: 40px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 44px; } }
+.nv-brand img { height: 72px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 72px; } }
 
 .nv-r {
   display: flex;
@@ -175,7 +175,7 @@ body {
 }
 
 .mn {
-  position: fixed; top: 56px; left: 0; right: 0; bottom: 0;
+  position: fixed; top: 96px; left: 0; right: 0; bottom: 0;
   background: var(--dk); z-index: 99;
   padding: 32px 24px;
   display: none; flex-direction: column;
@@ -203,10 +203,10 @@ body {
    ============================================================ */
 .hero { position: relative; background: var(--dk); padding-top: 0; }
 @media(min-width: 480px) {
-  .hero { padding-top: 57px; }
+  .hero { padding-top: 96px; }
 }
 @media(min-width: 768px) {
-  .hero { padding-top: 61px; }
+  .hero { padding-top: 96px; }
 }
 
 .hero-img {
@@ -215,7 +215,7 @@ body {
   background-size: cover;
   background-repeat: no-repeat;
   background-position: 50% 15%;
-  margin-top: 56px;
+  margin-top: 96px;
   position: relative;
 }
 @media(min-width: 480px) {
@@ -606,7 +606,7 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
   letter-spacing: .14em; text-transform: uppercase; color: var(--dm);
   display: inline-flex; align-items: center;
 }
-.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 48px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a {
   color: var(--dm); text-decoration: none;

--- a/projects/buffalo-river/index.html
+++ b/projects/buffalo-river/index.html
@@ -44,7 +44,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 64px; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-size: 1.0625rem; line-height: 1.65; overflow-x: hidden; }
 
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 20px; }
@@ -52,11 +52,11 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 
 /* NAV */
 .nv { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: rgba(13,27,42,.92); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-bottom: 1px solid var(--bd); }
-.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
+.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 96px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 40px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 44px; } }
+.nv-brand img { height: 72px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 72px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -71,7 +71,7 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .hm.on span:nth-child(3) { transform: rotate(-45deg) translate(4.5px,-4.5px); }
 @media(min-width: 768px) { .hm { display: none; } .nv-desk { display: flex; } }
 
-.mn { position: fixed; top: 56px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
+.mn { position: fixed; top: 96px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
 .mn.on { display: flex; }
 .mn a { font-size: 1.125rem; color: var(--tx); text-decoration: none; padding: 18px 0; border-bottom: 1px solid var(--bd); display: flex; justify-content: space-between; align-items: center; }
 .mn a.cur { color: var(--gd); }
@@ -82,8 +82,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .mn-pfg-s { font-size: 0.75rem; color: var(--dm); margin-top: 3px; }
 
 /* PAGE HEADER */
-.ph { padding: 96px 0 24px; }
-@media(min-width: 768px) { .ph { padding: 120px 0 36px; } }
+.ph { padding: 120px 0 24px; }
+@media(min-width: 768px) { .ph { padding: 140px 0 36px; } }
 .ph .lb { font-size: 0.6875rem; letter-spacing: .2em; text-transform: uppercase; color: var(--gd); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
 .ph .lb::before { content: ''; width: 20px; height: 1px; background: var(--gd); }
 .ph h1 { font-family: var(--fd); font-size: clamp(1.75rem, 5vw, 2.75rem); font-weight: 400; line-height: 1.15; color: var(--cr); margin-bottom: 16px; max-width: 820px; }
@@ -160,7 +160,7 @@ section { padding: 28px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 48px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/projects/index.html
+++ b/projects/index.html
@@ -43,7 +43,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 64px; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-size: 1.0625rem; line-height: 1.65; overflow-x: hidden; }
 
 .wrap { max-width: var(--mw); margin: 0 auto; padding: 0 20px; }
@@ -51,11 +51,11 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 
 /* NAV */
 .nv { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: rgba(13,27,42,.92); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); border-bottom: 1px solid var(--bd); }
-.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 60px; } }
+.nv-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+@media(min-width: 768px) { .nv-in { padding: 0 40px; height: 96px; } }
 .nv-brand { font-family: var(--fd); font-size: clamp(0.55rem, 2.2vw, 0.9375rem); letter-spacing: .12em; text-transform: uppercase; color: var(--cr); text-decoration: none; white-space: nowrap; flex-shrink: 1; min-width: 0; display: inline-flex; align-items: center; }
-.nv-brand img { height: 40px; width: auto; display: block; }
-@media(min-width: 768px) { .nv-brand img { height: 44px; } }
+.nv-brand img { height: 72px; width: auto; display: block; }
+@media(min-width: 768px) { .nv-brand img { height: 72px; } }
 .nv-r { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .nv-desk { display: none; gap: 28px; align-items: center; }
 .nv-desk a { font-size: 0.9375rem; color: var(--cr); opacity: 0.82; text-decoration: none; letter-spacing: .01em; transition: opacity .2s; }
@@ -70,7 +70,7 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .hm.on span:nth-child(3) { transform: rotate(-45deg) translate(4.5px,-4.5px); }
 @media(min-width: 768px) { .hm { display: none; } .nv-desk { display: flex; } }
 
-.mn { position: fixed; top: 56px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
+.mn { position: fixed; top: 96px; left: 0; right: 0; bottom: 0; background: var(--dk); z-index: 99; padding: 32px 24px; display: none; flex-direction: column; }
 .mn.on { display: flex; }
 .mn a { font-size: 1.125rem; color: var(--tx); text-decoration: none; padding: 18px 0; border-bottom: 1px solid var(--bd); display: flex; justify-content: space-between; align-items: center; }
 .mn a.cur { color: var(--gd); }
@@ -81,8 +81,8 @@ body { background: var(--dk); color: var(--tx); font-family: var(--fb); font-siz
 .mn-pfg-s { font-size: 0.75rem; color: var(--dm); margin-top: 3px; }
 
 /* PAGE HEADER */
-.ph { padding: 96px 0 24px; }
-@media(min-width: 768px) { .ph { padding: 120px 0 36px; } }
+.ph { padding: 120px 0 24px; }
+@media(min-width: 768px) { .ph { padding: 140px 0 36px; } }
 .ph .lb { font-size: 0.6875rem; letter-spacing: .2em; text-transform: uppercase; color: var(--gd); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
 .ph .lb::before { content: ''; width: 20px; height: 1px; background: var(--gd); }
 .ph h1 { font-family: var(--fd); font-size: clamp(1.75rem, 5vw, 2.75rem); font-weight: 400; line-height: 1.15; color: var(--cr); margin-bottom: 16px; max-width: 760px; }
@@ -134,7 +134,7 @@ section { padding: 24px 0; }
 footer { padding: 28px 20px; border-top: 1px solid var(--bd); margin-top: 36px; }
 .ft-top { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 14px; margin-bottom: 18px; max-width: var(--mw); margin-left: auto; margin-right: auto; }
 .ft-br { font-family: var(--fd); font-size: 0.6875rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dm); display: inline-flex; align-items: center; }
-.ft-br img { height: 32px; width: auto; display: block; opacity: .85; }
+.ft-br img { height: 48px; width: auto; display: block; opacity: .85; }
 .ft-social { display: flex; gap: 14px; align-items: center; }
 .ft-social a { color: var(--dm); text-decoration: none; display: flex; align-items: center; justify-content: center; min-height: 44px; min-width: 44px; transition: color .2s; }
 .ft-social a:hover { color: var(--tx); }

--- a/prompt-play/index.html
+++ b/prompt-play/index.html
@@ -47,7 +47,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 76px; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body {
   background: var(--cream);
   color: var(--ink);
@@ -76,11 +76,11 @@ a { color: var(--navy); }
   border-bottom: 1px solid transparent; transition: border-color .3s, background .3s;
 }
 .hd.solid { border-bottom-color: var(--line); background: rgba(247,241,227,.95); }
-.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-@media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
+.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+@media(min-width: 768px) { .hd-in { padding: 0 40px; min-height: 96px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 42px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 48px; } }
+.hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 72px; } }
 
 /* ============================================================ BUTTONS */
 .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--fd); font-weight: 600; font-size: 1rem; text-decoration: none; border-radius: 999px; padding: 13px 26px; min-height: 48px; border: 2px solid transparent; cursor: pointer; transition: transform .15s, box-shadow .15s, background .2s, color .2s, border-color .2s; }
@@ -107,8 +107,8 @@ section { padding: 52px 0; }
 .r.v { opacity: 1; transform: translateY(0); }
 
 /* ============================================================ HERO */
-.hero { padding: 110px 0 48px; text-align: center; position: relative; }
-@media(min-width: 768px) { .hero { padding: 140px 0 64px; } }
+.hero { padding: 140px 0 48px; text-align: center; position: relative; }
+@media(min-width: 768px) { .hero { padding: 160px 0 64px; } }
 .hero-tag { font-family: var(--fb); font-weight: 600; font-size: clamp(.72rem, 2.4vw, .95rem); letter-spacing: .26em; text-transform: uppercase; color: var(--navy); opacity: .85; }
 .wordmark { margin: 8px auto 6px; line-height: .86; font-size: inherit; font-weight: inherit; }
 .wm-prompt { display: block; font-family: var(--fd); font-weight: 700; color: var(--navy); font-size: clamp(3.6rem, 17vw, 9rem); letter-spacing: -.02em; }

--- a/prompt-play/kit/index.html
+++ b/prompt-play/kit/index.html
@@ -82,8 +82,8 @@ a { color: var(--navy); }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
 .hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
 @media(min-width: 768px) { .hd-brand img { height: 72px; } }
-.hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; display: none; }
-@media(min-width: 768px) { .hd-brand .tt { display: inline-block; } }
+.hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; position: absolute; width: 1px; height: 1px; clip: rect(0 0 0 0); white-space: nowrap; }
+@media(min-width: 768px) { .hd-brand .tt { position: static; width: auto; height: auto; clip: auto; display: inline-block; } }
 .hd-brand .tt b { font-weight: 600; }
 
 /* ============================================================ BUTTONS */

--- a/prompt-play/kit/index.html
+++ b/prompt-play/kit/index.html
@@ -83,7 +83,7 @@ a { color: var(--navy); }
 .hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
 @media(min-width: 768px) { .hd-brand img { height: 72px; } }
 .hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; display: none; }
-@media(min-width: 768px) { .hd-brand .tt { display: inline; } }
+@media(min-width: 768px) { .hd-brand .tt { display: inline-block; } }
 .hd-brand .tt b { font-weight: 600; }
 
 /* ============================================================ BUTTONS */

--- a/prompt-play/kit/index.html
+++ b/prompt-play/kit/index.html
@@ -48,7 +48,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 76px; }
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; scroll-padding-top: 100px; }
 body {
   background: var(--cream);
   color: var(--ink);
@@ -77,12 +77,13 @@ a { color: var(--navy); }
   border-bottom: 1px solid transparent; transition: border-color .3s, background .3s;
 }
 .hd.solid { border-bottom-color: var(--line); background: rgba(247,241,227,.95); }
-.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-@media(min-width: 768px) { .hd-in { padding: 0 40px; height: 68px; } }
+.hd-in { max-width: var(--mw); margin: 0 auto; padding: 0 16px; min-height: 96px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+@media(min-width: 768px) { .hd-in { padding: 0 40px; min-height: 96px; } }
 .hd-brand { font-family: var(--fb); font-weight: 600; font-size: clamp(.7rem, 2.4vw, .9rem); letter-spacing: .14em; text-transform: uppercase; color: var(--navy); text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; gap: 9px; }
-.hd-brand img { height: 34px; width: auto; display: block; flex-shrink: 0; }
-@media(min-width: 768px) { .hd-brand img { height: 40px; } }
-.hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.hd-brand img { height: 72px; width: auto; display: block; flex-shrink: 0; }
+@media(min-width: 768px) { .hd-brand img { height: 72px; } }
+.hd-brand .tt { min-width: 0; overflow: hidden; text-overflow: ellipsis; display: none; }
+@media(min-width: 768px) { .hd-brand .tt { display: inline; } }
 .hd-brand .tt b { font-weight: 600; }
 
 /* ============================================================ BUTTONS */
@@ -110,8 +111,8 @@ section { padding: 52px 0; }
 .r.v { opacity: 1; transform: translateY(0); }
 
 /* ============================================================ HERO */
-.hero { padding: 104px 0 44px; text-align: center; position: relative; }
-@media(min-width: 768px) { .hero { padding: 136px 0 60px; } }
+.hero { padding: 136px 0 44px; text-align: center; position: relative; }
+@media(min-width: 768px) { .hero { padding: 156px 0 60px; } }
 .hero-tag { font-family: var(--fb); font-weight: 600; font-size: clamp(.72rem, 2.4vw, .92rem); letter-spacing: .26em; text-transform: uppercase; color: var(--navy); opacity: .85; }
 .hero h1 { margin: 12px auto 6px; max-width: 16ch; font-size: clamp(2.5rem, 9vw, 4.6rem); letter-spacing: -.01em; }
 .hero h1 .surf { display: inline-block; font-family: var(--fm); color: var(--gold); font-weight: 400; transform: rotate(-2deg); text-shadow: 2px 2px 0 rgba(217,138,31,.22); }


### PR DESCRIPTION
## Summary

User reported the logo shipped in PR #36 still renders too small — "more like a favicon than the primary brand mark." They requested a substantially larger lockup: **72 px logo in a 96 px nav**, with the design directive *"the logo should feel confident and intentional, not tucked away like an afterthought."*

This PR is **CSS-only across 9 files** — same set PR #36 touched. Mobile and desktop are unified so there's no jump across the 768 px breakpoint.

## Resize map

| Surface | Was (mobile / desktop) | Now (both) |
|---|---|---|
| Dark nav `.nv-in` height (`index.html`, `events/`, `projects/`, `projects/buffalo-river/`) | 56 / 60 px | **96 px** |
| Dark nav `.nv-brand img` | 40 / 44 px | **72 px** |
| Cream header `.hd-in` min-height (`prompt-play/`, `prompt-play/kit/`, `first-contact/`, `first-contact/dashboard/`) | 60 / 68 px | **96 px** |
| Cream header `.hd-brand img` | 28–48 px | **72 px** |
| Dark utility header `.hd-brand img` (`first-contact/facilitator/`) | 30 / 34 px | **72 px** |
| Dark footer `.ft-br img` (4 dark pages) | 32 px | **48 px** |

## Sub-page label handling

On `prompt-play/kit/`, `first-contact/dashboard/`, and `first-contact/facilitator/`, the header has both the logo *and* a page label (`Prompt Play · Kit`, `First Contact · Dashboard`, `· Facilitator`). At 72 px logo + label + CTA button, a 320 px iPhone SE viewport overflows. Per direction, the label spans are **hidden below 768 px** (`display: none` with a desktop override). Logo gets the full brand presence on every mobile page; labels reappear at desktop where there's room.

## Cascades

Growing the nav from 56 → 96 px breaks several values that were tuned for the old nav. Each updated to maintain content breathing room below the taller fixed nav:

| Page | What | Was | Now |
|---|---|---|---|
| All 9 | `scroll-padding-top` | 64 / 72 / 76 px | **100 px** |
| `index.html` | `.mn { top }` (mobile menu) | 56 px | **96 px** |
| `index.html` | `.hero-img { margin-top }` | 56 px | **96 px** |
| `index.html` | `.hero { padding-top }` (480 / 768) | 57 / 61 px | **96 / 96 px** |
| `events/`, `projects/`, `projects/buffalo-river/` | `.ph { padding-top }` | 96 / 120 px | **120 / 140 px** |
| `prompt-play/` | `.hero { padding-top }` | 110 / 140 px | **140 / 160 px** |
| `prompt-play/kit/`, `first-contact/` | `.hero { padding-top }` | 104 / 132 / 136 px | **136 / 156 px** |
| `first-contact/dashboard/`, `first-contact/facilitator/` | n/a (sticky headers) | — | — |

## Mobile fit sanity

iPhone SE (320 px viewport): 16 px padding × 2 + 72 px logo (~108 px wide at 3:2) + 8 px gap + 44 px hamburger = 184 px → ~136 px slack. No overflow.

## Test plan

- [ ] Deploy preview at mobile (~360 px) — the logo on every page is unmistakably the primary brand mark; whale tail recognizable; wordmark legible without zoom.
- [ ] Header is vertically centered around the logo, hamburger / CTA sits comfortably on the right.
- [ ] `prompt-play/kit/`, `first-contact/dashboard/`, `first-contact/facilitator/`: page label is hidden on mobile; only logo + right-side control visible.
- [ ] Hero / page-header content sits below the nav with breathing space — no overlap, no big gap.
- [ ] Mobile menu (dark pages): when opened, starts below the 96 px nav (`top: 96px`) and fills the rest.
- [ ] Footer logo (dark pages) feels like a brand sign-off at 48 px, not a watermark.
- [ ] Desktop viewport (≥1024 px): same checks. Resizing across 768 px should be a smooth transition with no size jump.
- [ ] Click in-page anchors (`#now`, `#team`, `#reserve`) — destination sits below the 96 px nav with the 100 px `scroll-padding-top`, not behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkXmcp4ATxNJBRZFt9xBzg)_