### PR TITLE
[UX] Remove Prompt Play event promotion from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,39 +632,6 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
 }
 
 /* ============================================================
-   TONIGHT BANNER
-   ============================================================ */
-.tn-bnr {
-  display: none;
-  position: fixed; left: 0; right: 0; bottom: 0; z-index: 101;
-  background: var(--gd); color: var(--dk);
-  padding: 10px 16px; align-items: center; justify-content: center;
-  gap: 10px 16px; flex-wrap: wrap; text-align: center;
-  font-size: 0.875rem; font-weight: 500;
-  box-shadow: 0 -4px 18px rgba(0,0,0,.18);
-  text-decoration: none;
-}
-.tn-bnr:hover, .tn-bnr:active { background: #ffb538; }
-.tn-bnr-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--dk); animation: gp 2.2s infinite; }
-.tn-bnr b { font-weight: 700; }
-.tn-bnr-arr { font-weight: 700; }
-
-/* ============================================================
-   PROMPT PLAY PROMO (uses .now grid)
-   ============================================================ */
-.pp-poster {
-  padding: 0; display: flex; justify-content: center; align-items: center;
-  background: var(--d3); min-height: 280px; overflow: hidden;
-}
-@media(min-width: 768px) { .pp-poster { min-height: 400px; } }
-.pp-poster img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.pp-meta { display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 0.8125rem; color: var(--tx); margin: 10px 0 16px; }
-.pp-meta span { display: inline-flex; align-items: center; gap: 5px; }
-.pp-meta b { color: var(--cr); font-weight: 500; }
-.pp-ctas { display: flex; flex-direction: column; gap: 10px; margin-top: 16px; }
-@media(min-width: 480px) { .pp-ctas { flex-direction: row; } }
-
-/* ============================================================
    SCROLL ANIMATION
    ============================================================ */
 .r { opacity: 0; transform: translateY(14px); transition: opacity .5s, transform .5s; }
@@ -672,31 +639,8 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
 </style>
 </head>
 <body>
-<a class="tn-bnr" id="tn-bnr" href="/prompt-play/#reserve" data-ga="home_tonight_banner_click" aria-hidden="true"><span class="tn-bnr-dot" aria-hidden="true"></span><span>Tonight in Benton, AR · 7:00–9:00 PM · <b id="tn-bnr-title">Prompt Play</b></span><span class="tn-bnr-arr">Reserve a seat →</span></a>
-<script>
-(function(){
-  var b = document.getElementById('tn-bnr');
-  var t = document.getElementById('tn-bnr-title');
-  if (!b) return;
-  var nights = [
-    { start: new Date('2026-06-09T17:00:00-05:00'), end: new Date('2026-06-10T03:00:00-05:00'), label: 'Prompt Play · June 9' }
-  ];
-  var now = new Date();
-  for (var i = 0; i < nights.length; i++) {
-    if (now >= nights[i].start && now <= nights[i].end) {
-      if (t) t.textContent = nights[i].label;
-      b.style.display = 'flex';
-      b.setAttribute('aria-hidden', 'false');
-      var pad = function(){ document.body.style.paddingBottom = b.offsetHeight + 'px'; };
-      pad();
-      window.addEventListener('resize', pad);
-      break;
-    }
-  }
-})();
-</script>
-<nav class="nv" id="nv" data-ga="nav"><div class="nv-in"><a href="#" class="nv-brand" data-ga="nav_brand" aria-label="Tale Waters and Tides home"><img src="/assets/TalewatersandTides_Logo_White_Horizontal.png" alt="Tale Waters and Tides" loading="eager" decoding="async"></a><div class="nv-desk"><a href="#now" data-ga="nav_lab">Lab</a><a href="/projects/" data-ga="nav_projects">Projects</a><a href="/events/" data-ga="nav_events">Events</a><a href="/prompt-play/" data-ga="nav_promptplay">Prompt Play</a><a href="#team" data-ga="nav_about">About</a><a href="#collab" class="nv-cta" data-ga="nav_collaborate">Collaborate</a></div><div class="nv-r"><button class="hm" id="hm" aria-label="Menu"><span></span><span></span><span></span></button></div></div></nav>
-<div class="mn" id="mn"><a href="#now" onclick="cm()" data-ga="menu_lab">The Lab <span class="a">→</span></a><a href="/projects/" onclick="cm()" data-ga="menu_projects">Projects <span class="a">→</span></a><a href="/events/" onclick="cm()" data-ga="menu_events">Events <span class="a">→</span></a><a href="/prompt-play/" onclick="cm()" data-ga="menu_promptplay">Prompt Play <span class="a">→</span></a><a href="#team" onclick="cm()" data-ga="menu_about">About <span class="a">→</span></a><a href="#collab" onclick="cm()" data-ga="menu_collaborate">Collaborate <span class="a">→</span></a><a href="https://pocketfishinguide.com" class="mn-pfg nv-pfg" onclick="cm()" target="_blank" rel="noopener" data-ga="menu_pfg"><div class="mn-pfg-t">Pocket Fishing Guide →</div><div class="mn-pfg-s">Live fishing intelligence for Arkansas anglers</div></a></div>
+<nav class="nv" id="nv" data-ga="nav"><div class="nv-in"><a href="#" class="nv-brand" data-ga="nav_brand" aria-label="Tale Waters and Tides home"><img src="/assets/TalewatersandTides_Logo_White_Horizontal.png" alt="Tale Waters and Tides" loading="eager" decoding="async"></a><div class="nv-desk"><a href="#now" data-ga="nav_lab">Lab</a><a href="/projects/" data-ga="nav_projects">Projects</a><a href="#team" data-ga="nav_about">About</a><a href="#collab" class="nv-cta" data-ga="nav_collaborate">Collaborate</a></div><div class="nv-r"><button class="hm" id="hm" aria-label="Menu"><span></span><span></span><span></span></button></div></div></nav>
+<div class="mn" id="mn"><a href="#now" onclick="cm()" data-ga="menu_lab">The Lab <span class="a">→</span></a><a href="/projects/" onclick="cm()" data-ga="menu_projects">Projects <span class="a">→</span></a><a href="#team" onclick="cm()" data-ga="menu_about">About <span class="a">→</span></a><a href="#collab" onclick="cm()" data-ga="menu_collaborate">Collaborate <span class="a">→</span></a><a href="https://pocketfishinguide.com" class="mn-pfg nv-pfg" onclick="cm()" target="_blank" rel="noopener" data-ga="menu_pfg"><div class="mn-pfg-t">Pocket Fishing Guide →</div><div class="mn-pfg-s">Live fishing intelligence for Arkansas anglers</div></a></div>
 
 <div class="hero" data-ga-section="hero">
   <div class="hero-img" id="heroBg">
@@ -708,8 +652,6 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
 <div class="belief r" data-ga-section="belief"><p>The best outdoor technology comes from people who use it.</p></div>
 
 <section id="now" data-ga-section="lab_now"><div class="wrap"><div class="lb r">Now</div><h2 class="st r">What we're building.</h2><div class="now r"><div class="phone-frame"><div class="phone"><div class="phone-screen" id="pfgImg"></div></div></div><div class="now-bd"><div class="now-hd"><div class="now-t">Pocket Fishing Guide</div><span class="bdg bdg-l">LIVE</span></div><div class="now-d">Live fishing intelligence for Arkansas anglers. Real-time USGS water temps, NWS barometric pressure, spawn phase data across 39 water bodies and 27 species.</div><div class="now-ev">AI-native. Solo-built. Learning and shipping every day. Could white-label. Could expand beyond fishing. We're letting the product lead.</div><a href="https://pocketfishinguide.com" class="now-link" data-ga="lab_open_pfg">Open Pocket Fishing Guide →</a></div></div></div></section>
-
-<section id="prompt-play-promo" class="sf" data-ga-section="lab_prompt_play"><div class="wrap"><div class="lb r">Happening Now</div><h2 class="st r">Prompt Play — An AI Playground for Curious Minds.</h2><div class="now r"><div class="pp-poster"><img src="/assets/prompt-play-june9.PNG" alt="Prompt Play — an AI playground for curious minds at Hey, Let's Play in Benton, AR. Tuesday, June 9, 2026. One night, four topics." loading="lazy" decoding="async"></div><div class="now-bd"><div class="now-hd"><div class="now-t">Prompt Play</div><span class="bdg bdg-l">LIVE</span></div><div class="now-d">One night. Four topics. Limitless possibilities. A free, grassroots creative-AI playground where curious minds, families, and builders explore what's possible when you treat AI like a creative partner.</div><div class="pp-meta"><span>📍 <b>Hey, Let's Play</b> · Benton, AR</span><span>📅 <b>Tuesday, June 9, 2026</b></span><span>🕖 <b>7:00–9:00 PM CT</b></span></div><div class="now-ev">Not a class. Not a webinar. A creative playground for the curious. One free night, four topics — First Contact, Fishing with AI, Prompt to Manufacturing, and AI Tinkerers. Just 25 seats — coffee provided, family-friendly.</div><div class="pp-ctas"><a href="/prompt-play/#reserve" class="bg" data-ga="home_pp_reserve">Reserve your free seat →</a><a href="/prompt-play/" class="bo" data-ga="home_pp_open">Explore the topics</a></div></div></div></div></section>
 
 <section id="exploring" class="sf" data-ga-section="lab_exploring"><div class="wrap"><div class="lb r">Exploring</div><h2 class="st r">What we're learning toward.</h2><div class="ex-grid"><div class="ex r"><div class="ex-hd"><div class="ex-t">Guide marketplace</div><span class="bdg bdg-e">EXPLORING</span></div><div class="ex-tam">$89.8B</div><div class="ex-tam-s">Fishing tourism market (2025)</div><div class="ex-d">57 million Americans fish annually. No dominant platform connecting anglers with local guides.</div></div><div class="ex r"><div class="ex-hd"><div class="ex-t">Platform expansion</div><span class="bdg bdg-e">EXPLORING</span></div><div class="ex-d">White-label PFG for other states? Broader outdoor intelligence?</div><div class="ex-q">We don't have the answer yet. We're building toward it.</div></div><a class="ex r" href="/projects/" data-ga="lab_projects" style="text-decoration:none;display:flex;flex-direction:column;color:inherit;"><div class="ex-hd"><div class="ex-t">Lab Projects</div><span class="bdg bdg-e">PORTFOLIO</span></div><div class="ex-d">Where we collect everything we ship from the lab — live products, AI experiments like the Quest, and field-tested demos. A growing portfolio of small things that teach us bigger things.</div><div class="ex-q" style="color:var(--gd);">See all lab projects →</div></a></div></div></section>
 
@@ -724,7 +666,7 @@ footer { padding: 28px 20px; border-top: 1px solid var(--bd); }
 
 <div class="bea" data-ga-section="bea_context">Operating in a <b>$1.3 trillion</b> economy · <b>5.2M</b> jobs · <b>2.4%</b> of GDP — BEA 2024</div>
 
-<footer data-ga-section="footer"><div class="ft-top"><span class="ft-br"><img src="/assets/TalewatersandTides_Logo_White_Horizontal.png" alt="Tale Waters and Tides" loading="lazy" decoding="async"></span><div class="ft-social"><a href="https://www.facebook.com/talewatersandtides" target="_blank" rel="noopener" aria-label="Facebook" data-ga="social_facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a><a href="https://www.tiktok.com/@coreytheaideaguy" target="_blank" rel="noopener" aria-label="TikTok" data-ga="social_tiktok"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.59 6.69a4.83 4.83 0 01-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 01-2.88 2.5 2.89 2.89 0 01-2.89-2.89 2.89 2.89 0 012.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 00-.79-.05A6.34 6.34 0 003.15 15.2a6.34 6.34 0 006.34 6.34 6.34 6.34 0 006.34-6.34V8.87a8.16 8.16 0 004.76 1.52v-3.4a4.85 4.85 0 01-1-.3z"/></svg></a><a href="https://www.linkedin.com/in/boelkens/" target="_blank" rel="noopener" aria-label="LinkedIn" data-ga="social_linkedin"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg></a><a href="https://pocketfishinguide.com" target="_blank" rel="noopener" aria-label="PFG" data-ga="social_pfg"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg></a></div></div><div class="ft-lk"><a href="#now">Lab</a><a href="/projects/" data-ga="footer_projects">Projects</a><a href="/events/" data-ga="footer_events">Events</a><a href="/prompt-play/" data-ga="footer_promptplay">Prompt Play</a><a href="#team">About</a><a href="#collab">Collaborate</a><a href="https://pocketfishinguide.com">PFG</a><a href="/projects/quest/" data-ga="footer_quest">Quest</a></div><div class="ft-cp">© 2026 Tale Waters and Tides, LLC · Little Rock, Arkansas</div></footer>
+<footer data-ga-section="footer"><div class="ft-top"><span class="ft-br"><img src="/assets/TalewatersandTides_Logo_White_Horizontal.png" alt="Tale Waters and Tides" loading="lazy" decoding="async"></span><div class="ft-social"><a href="https://www.facebook.com/talewatersandtides" target="_blank" rel="noopener" aria-label="Facebook" data-ga="social_facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg></a><a href="https://www.tiktok.com/@coreytheaideaguy" target="_blank" rel="noopener" aria-label="TikTok" data-ga="social_tiktok"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.59 6.69a4.83 4.83 0 01-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 01-2.88 2.5 2.89 2.89 0 01-2.89-2.89 2.89 2.89 0 012.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 00-.79-.05A6.34 6.34 0 003.15 15.2a6.34 6.34 0 006.34 6.34 6.34 6.34 0 006.34-6.34V8.87a8.16 8.16 0 004.76 1.52v-3.4a4.85 4.85 0 01-1-.3z"/></svg></a><a href="https://www.linkedin.com/in/boelkens/" target="_blank" rel="noopener" aria-label="LinkedIn" data-ga="social_linkedin"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg></a><a href="https://pocketfishinguide.com" target="_blank" rel="noopener" aria-label="PFG" data-ga="social_pfg"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg></a></div></div><div class="ft-lk"><a href="#now">Lab</a><a href="/projects/" data-ga="footer_projects">Projects</a><a href="#team">About</a><a href="#collab">Collaborate</a><a href="https://pocketfishinguide.com">PFG</a><a href="/projects/quest/" data-ga="footer_quest">Quest</a></div><div class="ft-cp">© 2026 Tale Waters and Tides, LLC · Little Rock, Arkansas</div></footer>
 
 <script>
 const h=document.getElementById('hm'),m=document.getElementById('mn');h.addEventListener('click',()=>{h.classList.toggle('on');m.classList.toggle('on');document.body.style.overflow=m.classList.contains('on')?'hidden':''});function cm(){h.classList.remove('on');m.classList.remove('on');document.body.style.overflow=''}


### PR DESCRIPTION
## What

Removes the time-sensitive Prompt Play event promotion from the marketing homepage (`index.html`) for now.

## Changes

- **Tonight banner** — removed the fixed `Tonight in Benton, AR · Prompt Play` banner and its date-scheduling script
- **Promo section** — removed the `#prompt-play-promo` "Happening Now" section
- **Navigation** — removed the `Prompt Play` and `Events` links from the desktop nav, mobile menu, and footer
- **CSS** — dropped the now-dead `.tn-bnr*` and `.pp-*` rules

## Scope

Homepage only. The `/events/`, `/prompt-play/` (+ `/prompt-play/kit/`), and `/first-contact/` pages are **left intact** — just unlinked from the homepage — so the promotion is easy to restore later. `llms.txt`, the QR card asset, and `scripts/gen-md.mjs` were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bt3iiB6dtkp9x82N6xLjg

---
_Generated by [Claude Code](https://claude.ai/code/session_016Bt3iiB6dtkp9x82N6xLjg)_