### PR TITLE
[Feature] Competitive dashboard v1.3 — June 29, 2026 scan

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -501,8 +501,8 @@
     </div>
   </div>
   <div class="report-meta">
-    <div class="date">Report Date: June 25, 2026</div>
-    <div class="version">v1.2 — Q2 2026 Scan (updated)</div>
+    <div class="date">Report Date: June 29, 2026</div>
+    <div class="version">v1.3 — Q2 2026 Scan (June 29 update)</div>
   </div>
 </header>
 
@@ -533,7 +533,13 @@
     <div class="alert alert-info">
       <span class="alert-icon">&#9654;</span>
       <div class="alert-body">
-        <strong>June 25 Scan Update (v1.2):</strong> New intelligence added — onX Fish officially in market (April 2025, backed by onX outdoor suite), FishRadar App marine sensor integration (Sept 2025), AquaTrack Labs acquires HookMaster Digital (Aug 2025), BassForce &amp; BassForecast confirmed as AI-native bass specialists. Market size revised upward to $1.28B (2025) growing to $2.35B by 2032. No PFG clones or copies detected.
+        <strong>June 29 Scan Update (v1.3):</strong> Three new AI-native bite prediction apps confirmed on App Store + Google Play: <em>FishGuide AI</em> (Predictive Bite Score), <em>Fish AI</em> (10-day spot suggestions, updated June 16 2026), and <em>Fish AI Forecast</em> (weather + moon + tides). BUBBA x Major League Fishing launched <em>SCORETRACKER LIVE</em> (tournament platform, spring 2026). FlyFishFinder shipped <em>Prime Waters</em> personal assistant feature. <strong>Critical: PocketFishingGuide is not indexed anywhere</strong> — live web scan confirms zero search visibility for PFG by name or URL. onWater now has a dedicated <a href="https://www.onwaterapp.com/state/arkansas" target="_blank" rel="noopener">Arkansas state page</a>. Fishbrain user count dropping (15M vs. previously cited 20M). No PFG clones detected.
+      </div>
+    </div>
+    <div class="alert alert-info" style="margin-top:-8px;">
+      <span class="alert-icon">&#9654;</span>
+      <div class="alert-body">
+        <strong>June 25 Scan Update (v1.2):</strong> onX Fish officially in market (April 2025, backed by onX outdoor suite), FishRadar App marine sensor integration (Sept 2025), AquaTrack Labs acquires HookMaster Digital (Aug 2025), BassForce &amp; BassForecast confirmed as AI-native bass specialists. Market size revised upward to $1.28B (2025) growing to $2.35B by 2032.
       </div>
     </div>
 
@@ -700,7 +706,13 @@
     <div class="alert alert-info" style="margin-top:20px;">
       <span class="alert-icon">ℹ</span>
       <div class="alert-body">
-        <strong>No copies or clones found.</strong> June 25, 2026 scan across app stores, GitHub, Reddit fishing communities, fishing forums, and web search returned no results mimicking PFG's hyperlocal Arkansas intelligence model. The brand name is largely un-indexed — both a risk (discoverability) and a window (SEO + first-mover). Confirmed across two scan cycles (June 23 + June 25).
+        <strong>No copies or clones found.</strong> June 29, 2026 scan across app stores, GitHub, Reddit fishing communities, fishing forums, and web search returned no results mimicking PFG's hyperlocal Arkansas intelligence model. Confirmed across three scan cycles (June 23, June 25, June 29).
+      </div>
+    </div>
+    <div class="alert alert-warn" style="margin-top:12px;">
+      <span class="alert-icon">⚠</span>
+      <div class="alert-body">
+        <strong>Critical: PFG is not findable.</strong> June 29 live web search for "pocket fishing guide", "pocket fishing guide arkansas", "Arkansas crappie fishing app", and "White Bass app Arkansas" returned zero PFG results. onWater's <a href="https://www.onwaterapp.com/state/arkansas" target="_blank" rel="noopener">Arkansas state page</a> ranks instead. PFG's absence from search is a higher-urgency gap than any product feature — a product no one can discover is invisible to its market.
       </div>
     </div>
 
@@ -1072,6 +1084,124 @@
                 <li><strong>BFR model insight:</strong> A daily 1–10 "fishing score" with push alerts is a powerful retention mechanic. PFG's planned spawn-window push notifications are the closest equivalent — prioritize this feature.</li>
                 <li><strong>Not a threat today:</strong> Audience segment doesn't overlap heavily with PFG's recreational + beginner focus. Becomes relevant if either platform expands to panfish or regional markets.</li>
               </ul>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- AI Bite Prediction Class — NEW June 29 -->
+      <div class="comp-card">
+        <div class="comp-card-header">
+          <div class="comp-icon" style="background:rgba(139,92,246,0.15);">🤖</div>
+          <div>
+            <h3>AI Bite Prediction Class</h3>
+            <div class="comp-meta">FishGuide AI · Fish AI · Fish AI Forecast — App Store + Google Play · 2026</div>
+            <div class="tag-row" style="margin-top:6px;">
+              <span class="badge badge-yellow">Medium — Watch</span>
+              <span class="badge badge-purple">New Crop</span>
+              <span class="badge badge-blue">AI-Native</span>
+            </div>
+          </div>
+        </div>
+        <div class="comp-card-body">
+          <p>Three new AI-native bite prediction apps confirmed live in 2026. <strong>FishGuide AI</strong> (App Store) features a Predictive Bite Score — best days and times to fish. <strong>Fish AI</strong> (App Store + Google Play, updated June 16 2026) delivers daily personalized spot suggestions up to 10 days in advance with science-based prediction models. <strong>Fish AI Forecast</strong> (Google Play) applies AI to weather, tides, moon phase, and past catch data for timing windows. All three are subscription-gated.</p>
+          <div class="comp-features">
+            <span class="feature-chip">Predictive Bite Score</span>
+            <span class="feature-chip">10-Day Spot Forecast</span>
+            <span class="feature-chip">Moon + Tides + Weather</span>
+            <span class="feature-chip">Species Behavior AI</span>
+            <span class="feature-chip">Subscription Model</span>
+          </div>
+          <details>
+            <summary>Full Analysis</summary>
+            <div class="detail-body">
+              <ul>
+                <li><strong>Market signal:</strong> Three independent AI bite-prediction apps entering simultaneously in 2026 confirms this is a validated demand category — anglers will pay for "when to go" intelligence. PFG's spawn-phase alerts and lure scoring are the condition-native equivalent.</li>
+                <li><strong>Their weakness — PFG's edge:</strong> All three apps rely on statistical solunar/historical models. They do not integrate live hydrology data (USGS gauges, river flow, water temperature). PFG's real-time USGS/NWS/USACE pipeline is a genuine data moat these apps cannot replicate without a federal data partnership.</li>
+                <li><strong>Subscription fatigue risk:</strong> All three require paid tiers for meaningful predictions. PFG's zero-paywall model is a direct counter-positioning message.</li>
+                <li><strong>Arkansas depth:</strong> None are Arkansas-specific. National coverage with shallow local calibration — exactly PFG's white space.</li>
+                <li><strong>Action:</strong> Monitor user reviews for "what they got wrong" — those failure cases reveal where real-time hydrology data matters and what PFG should emphasize in messaging.</li>
+              </ul>
+              <p style="margin-top:10px;">
+                <a href="https://apps.apple.com/us/app/fishing-app-fishguide-ai/id6747693672" target="_blank" rel="noopener">FishGuide AI — App Store →</a> ·
+                <a href="https://apps.apple.com/us/app/fish-ai-spot-prediction-app/id6740141927" target="_blank" rel="noopener">Fish AI — App Store →</a> ·
+                <a href="https://play.google.com/store/apps/details?id=com.vsvamrti.fishai.forecast" target="_blank" rel="noopener">Fish AI Forecast — Google Play →</a>
+              </p>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- BUBBA x MLF SCORETRACKER LIVE — NEW June 29 -->
+      <div class="comp-card">
+        <div class="comp-card-header">
+          <div class="comp-icon" style="background:rgba(249,115,22,0.15);">🏆</div>
+          <div>
+            <h3>BUBBA x MLF SCORETRACKER LIVE</h3>
+            <div class="comp-meta">American Outdoor Brands (AOUT) · Major League Fishing · Spring 2026</div>
+            <div class="tag-row" style="margin-top:6px;">
+              <span class="badge badge-blue">Low Direct Threat</span>
+              <span class="badge badge-purple">Tournament Niche</span>
+              <span class="badge badge-orange">Market Signal</span>
+            </div>
+          </div>
+        </div>
+        <div class="comp-card-body">
+          <p>BUBBA (American Outdoor Brands) partnered with Major League Fishing to launch SCORETRACKER LIVE — a real-time tournament hosting and live scoring platform for all levels, from neighborhood derbies to pro leagues. Uses BUBBA Smart Fish Scales to auto-sync catch weights. Spectators can follow live from anywhere. Not a fishing intelligence app — a tournament management platform. Low direct PFG overlap.</p>
+          <div class="comp-features">
+            <span class="feature-chip">Real-Time Tournament Scoring</span>
+            <span class="feature-chip">Smart Scale Integration</span>
+            <span class="feature-chip">Live Spectator View</span>
+            <span class="feature-chip">Tournament Organizer Tools</span>
+            <span class="feature-chip">Catch-Weigh-Release</span>
+          </div>
+          <details>
+            <summary>Full Analysis</summary>
+            <div class="detail-body">
+              <ul>
+                <li><strong>Market signal — hardware + software convergence:</strong> Following FishRadar's marine sensor integration (Sept 2025), BUBBA x MLF is the second major hardware-to-software platform play in 6 months. Smart scales + apps + real-time scoring = an emerging category of hardware-native fishing platforms.</li>
+                <li><strong>Tournament niche lock-in:</strong> SCORETRACKER LIVE targets organized fishing events — from local clubs to high school teams. This audience segment is adjacent to but distinct from PFG's recreational angler + beginner target. Low overlap today.</li>
+                <li><strong>Consolidation signal:</strong> American Outdoor Brands (AOUT) is a well-capitalized outdoor conglomerate (BUBBA, Old Timer, more). Their entry into app-enabled tournament tools signals institutional capital entering the connected fishing space.</li>
+                <li><strong>Indirect threat vector:</strong> If SCORETRACKER LIVE expands to include fishing intelligence, conditions, or local guide integration (they already have MLF pro angler relationships), they could enter PFG's roadmap lane with significant brand backing.</li>
+                <li><strong>PFG opportunity:</strong> Arkansas fishing tournaments (local bass clubs, crappie tournaments on Maumelle, Ouachita) are a natural channel. PFG conditions data + SCORETRACKER LIVE's scoring = a potential integration story to explore.</li>
+              </ul>
+              <p style="margin-top:10px;"><a href="https://majorleaguefishing.com/press-releases/bubba-x-major-league-fishing-to-launch-scoretracker-live-tournament-platform-for-all-anglers-organizers/" target="_blank" rel="noopener">SCORETRACKER LIVE press release →</a></p>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- FlyFishFinder Prime Waters — NEW June 29 -->
+      <div class="comp-card">
+        <div class="comp-card-header">
+          <div class="comp-icon" style="background:rgba(16,185,129,0.15);">🪰</div>
+          <div>
+            <h3>FlyFishFinder — Prime Waters</h3>
+            <div class="comp-meta">Independent · Fly Fishing Niche · New 2026 Feature</div>
+            <div class="tag-row" style="margin-top:6px;">
+              <span class="badge badge-blue">Low Direct Threat</span>
+              <span class="badge badge-green">Concept Validation</span>
+            </div>
+          </div>
+        </div>
+        <div class="comp-card-body">
+          <p>FlyFishFinder (220,000+ mapped rivers and access points, all 50 states) launched "Prime Waters" in 2026 — described as a personal assistant that alerts you when water is prime for fishing. Fly-fishing focused, so minimal Arkansas overlap. However, the feature is a direct conceptual match to PFG's planned spawn-window push notifications — validating the market demand for condition-triggered alerts.</p>
+          <div class="comp-features">
+            <span class="feature-chip">Prime Waters Alerts</span>
+            <span class="feature-chip">220K+ River Access Points</span>
+            <span class="feature-chip">Condition Triggers</span>
+            <span class="feature-chip">Fly Fishing Focus</span>
+          </div>
+          <details>
+            <summary>Full Analysis</summary>
+            <div class="detail-body">
+              <ul>
+                <li><strong>Concept validation:</strong> Prime Waters = "tell me when conditions are right, don't make me check." This is exactly PFG's planned spawn-window push notification model. Another data point confirming the feature is both technically viable and user-demanded.</li>
+                <li><strong>Fly fishing vs. warm-water species:</strong> FlyFishFinder is optimized for trout, salmon, and fly-fishing rivers — not White Bass + Crappie on Arkansas reservoirs. Very low direct audience overlap.</li>
+                <li><strong>Arkansas river coverage:</strong> Their 220K+ access points include Arkansas rivers (White River trout fishery), but their condition intelligence isn't calibrated to the USGS gauge data PFG uses for warm-water species forecasting.</li>
+                <li><strong>Action:</strong> No immediate action needed. File as further confirmation that condition-triggered push alerts should be prioritized in PFG's Q3 2026 roadmap lane.</li>
+              </ul>
+              <p style="margin-top:10px;"><a href="https://flyfishfinder.com/the-best-fly-fishing-apps-in-2026/" target="_blank" rel="noopener">FlyFishFinder Prime Waters coverage →</a></p>
             </div>
           </details>
         </div>
@@ -1845,6 +1975,24 @@
             <div class="tl-body">Photo-based species identification + size estimation arriving. Will add educational value and beginner hook. Raises accessibility bar across the market.</div>
           </div>
 
+          <div class="tl-event competitor">
+            <div class="tl-date">Spring 2026</div>
+            <div class="tl-title">BUBBA x Major League Fishing Launch SCORETRACKER LIVE</div>
+            <div class="tl-body">American Outdoor Brands (AOUT) + MLF launch a real-time tournament scoring platform integrated with BUBBA Smart Fish Scales. Targets all tournament levels from neighborhood derbies to pro leagues. Signals hardware + software convergence and institutional capital entering the connected fishing space. <a href="https://majorleaguefishing.com/press-releases/bubba-x-major-league-fishing-to-launch-scoretracker-live-tournament-platform-for-all-anglers-organizers/" target="_blank" rel="noopener">Press release →</a></div>
+          </div>
+
+          <div class="tl-event competitor">
+            <div class="tl-date">2026</div>
+            <div class="tl-title">FlyFishFinder Launches "Prime Waters" Condition Alerts</div>
+            <div class="tl-body">FlyFishFinder (220,000+ rivers, 50 states) ships Prime Waters — a personal assistant that notifies anglers when water is prime for fishing. Fly-fishing niche, but concept-validates PFG's planned spawn-window push alert feature. Third major platform in 12 months shipping condition-triggered alerts.</div>
+          </div>
+
+          <div class="tl-event competitor">
+            <div class="tl-date">2026 (confirmed June 29 scan)</div>
+            <div class="tl-title">AI Bite Prediction App Crop Emerges</div>
+            <div class="tl-body">Three new AI-native bite prediction apps confirmed on App Store and Google Play: <em>FishGuide AI</em> (Predictive Bite Score), <em>Fish AI</em> (10-day spot forecasts, last updated June 16 2026), and <em>Fish AI Forecast</em> (weather + moon + tides + catch history). All subscription-based. Validates that anglers will pay for "when to go" AI intelligence — but none use live USGS hydrology data, which is PFG's core moat.</div>
+          </div>
+
         </div>
       </div>
 
@@ -1922,7 +2070,21 @@
       <p>Ranked by impact × urgency. High = act this quarter. Medium = plan for next quarter. Low = monitor.</p>
     </div>
 
+    <div class="alert alert-warn" style="margin-bottom:20px;">
+      <span class="alert-icon">⚠</span>
+      <div class="alert-body">
+        <strong>June 29 Critical Finding:</strong> A live web search for "pocket fishing guide", "pocket fishing guide arkansas", and related queries returns zero PFG results. PFG is not indexed, not discoverable, and not branded in any search channel. When competitors are actively named in search roundups, PFG is invisible. This is a higher urgency than any product feature gap.
+      </div>
+    </div>
+
     <div class="opp-grid">
+
+      <div class="opp-card high">
+        <div class="opp-priority">HIGH PRIORITY — CRITICAL (New June 29)</div>
+        <h4>SEO Emergency: PFG Has Zero Web Presence</h4>
+        <p>Live scan on June 29, 2026 confirms PFG does not appear in any web search for its own name or Arkansas fishing queries. When an angler searches "Arkansas fishing app," "White Bass spawn app," or "pocket fishing guide," onWater, Fishbrain, and AGFC appear — not PFG. This is the single highest-priority gap: the product exists but no one can find it.</p>
+        <div class="opp-action">→ Immediate actions: (1) Add og:title, og:description, og:image to index.html. (2) Create sitemap.xml, submit to Google Search Console. (3) Add JSON-LD SoftwareApplication schema markup. (4) Write 5 Arkansas-specific landing paragraphs with keywords: "Arkansas crappie fishing app", "Lake Maumelle conditions", "White Bass spawn Arkansas", "free Arkansas fishing app". (5) Share in r/arkansasfishing, Arkansas Facebook fishing groups. All zero cost, &lt;4 hours.</div>
+      </div>
 
       <div class="opp-card high">
         <div class="opp-priority">High Priority</div>


### PR DESCRIPTION
## Summary

- **Critical SEO finding:** PFG has zero web search presence — searching "pocket fishing guide arkansas" surfaces only competitors (onWater, Fishbrain, AGFC). New highest-priority opportunity card added with specific action items (og tags, sitemap.xml, JSON-LD schema, keyword landing paragraphs, Reddit/Facebook seeding).
- **3 new AI-native competitors confirmed** on App Store + Google Play: FishGuide AI (Predictive Bite Score), Fish AI (10-day spot suggestions), and Fish AI Forecast (weather + moon + tides). Added as "AI Bite Prediction Class" competitor card.
- **BUBBA x MLF SCORETRACKER LIVE** launched spring 2026 — tournament platform signaling hardware+software convergence and institutional capital entering the space.
- **FlyFishFinder Prime Waters** personal assistant validates PFG's planned spawn-window push alerts roadmap item.
- **onWater** confirmed dedicated Arkansas state page, increasing direct regional competition.
- **Fishbrain user count corrected** to 15M (down from previously cited 20M).
- **No PFG clones detected** — third consecutive scan confirmation (June 23, 25, 29).

## Changes

- `competitive-dashboard.html`: bumped to v1.3 / June 29, 2026
  - New v1.3 alert banner in Executive Summary tab
  - 3 new competitor cards (AI Bite Prediction Class, BUBBA x MLF, FlyFishFinder)
  - 3 new timeline events in Market Timeline tab
  - Critical SEO opportunity card added at top of Opportunities tab
  - Updated "no clones" alert with 3-scan confirmation + "PFG not findable" warning

## Test plan

- [ ] Open `competitive-dashboard.html` in browser and verify all 8 tabs load correctly
- [ ] Confirm v1.3 alert banner appears at top of Executive Summary
- [ ] Confirm 3 new competitor cards appear in Competitors tab
- [ ] Confirm SEO opportunity card appears first in Opportunities tab
- [ ] Confirm 3 new timeline events render in Market Timeline tab
- [ ] Verify no layout regressions on mobile viewport (below 900px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132bCbQ6sSoDQW1PmNYpx6H

---
_Generated by [Claude Code](https://claude.ai/code/session_0132bCbQ6sSoDQW1PmNYpx6H)_