### PR TITLE
[Chore] Competitive dashboard v1.6 — July 6, 2026 scan

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 2, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.5</div>
+    <div class="last-updated">Refreshed: July 6, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.6</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">50.1M</span><span class="stat-label">US Anglers</span></div>
   <div class="stat"><span class="stat-val">45%</span><span class="stat-label">Use Mobile Apps</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> No PFG clones or mentions detected. onX Fish now covers 11 states including Missouri, AR&rsquo;s northern neighbor &mdash; expansion is closing in. Fishbrain quietly killed its marketplace. GilledIt is adding AI photo fish-ID in Q3. PFG has zero editorial visibility.
+    <strong>Signal:</strong> FishAngler &mdash; previously tagged 100% free &mdash; just launched a paywalled &ldquo;VIP&rdquo; tier gating forecasts and location data, and is drawing real user backlash. PFG&rsquo;s free-core bet looks stronger. onX Fish&rsquo;s latest expansion went to Montana (home turf), not south toward AR; Missouri is still the nearest border, unchanged. PFG&rsquo;s own site is now surfacing in organic search for branded queries &mdash; a first, though still no editorial or community mentions.
   </div>
 </div>
 
@@ -343,25 +343,23 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; June 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
       <ul>
         <li><strong>No direct Arkansas-focused clones detected.</strong> PFG&rsquo;s hyper-local depth remains unchallenged at the state level.</li>
-        <li><strong>GilledIt</strong> is the breakout app of 2026 &mdash; free, gamified, marketplace-enabled, topped all six major roundups reviewed. It just announced <strong>Fishial.AI-powered photo fish identification landing Q3 2026</strong>, closing one of its last gaps versus Fishbox/Fishbrain.</li>
-        <li><strong>onX Fish</strong> has expanded from a May 2026 Android launch to <strong>11 states</strong> (MN, WI, MI, ND, IN, OH, IL, SD, IA, MO, MT) at $34.99/yr with a 7-day trial. <strong>Missouri now borders the watch zone directly north of Arkansas</strong> &mdash; the clearest expansion signal yet.</li>
-        <li><strong>Fishbox</strong> added an AI catch assistant targeting beginners &mdash; directly competes with PFG&rsquo;s planned education tier.</li>
-        <li><strong>Fishbrain</strong> quietly shut down its much-hyped tackle marketplace &mdash; a validation that free, focused apps beat bolted-on commerce for this audience.</li>
-        <li>A wave of niche <strong>AI-native fishing apps</strong> (FishGPT, Fish AI, standalone Fishial.AI) surfaced in searches &mdash; all general-purpose chat/ID tools with no state-specific or condition-aware intelligence. Logged as a watch-list category, not yet a threat.</li>
+        <li><strong>FishAngler pulled back from its free model.</strong> It launched a &ldquo;FishAngler VIP&rdquo; tier gating its FishForecast (feeding windows, 14-day outlook), solunar calendar, and exact location data &mdash; the exact features that made it a free-model threat. User sentiment has turned sharply negative over the paywall plus a confusing UI redesign.</li>
+        <li><strong>onX Fish</strong> expanded to Montana (May 2026) &mdash; its first move beyond the Midwest, and notably its home state (onX is HQ&rsquo;d in Missoula), not a push south toward Arkansas. Still 11 states at $34.99/yr; Missouri remains the nearest border, unchanged since the last scan.</li>
+        <li><strong>GilledIt</strong>&rsquo;s Fishial.AI-powered photo fish ID remains slated for Q3 2026 &mdash; not yet shipped, no change since last scan.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Zero editorial mentions</strong> found in any 2026 fishing app roundup or review site.</li>
-        <li>No Reddit threads, fishing forum posts, or social media mentions found for &ldquo;PocketFishingGuide.&rdquo;</li>
+        <li><strong>First organic search signal:</strong> pocketfishinguide.com/waters now surfaces directly in Google results for &ldquo;Pocket Fishing Guide Arkansas app&rdquo;-style queries. It didn&rsquo;t as of the July 2 scan &mdash; the site is starting to get indexed.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
+        <li>Still no Reddit threads, fishing forum posts, or social media mentions found for &ldquo;Pocket Fishing Guide.&rdquo;</li>
         <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
         <li><strong>onWater Fish</strong> covers Arkansas water maps but lacks condition-aware lure scoring or spawn phase tracking.</li>
-        <li>Fishbrain and FishAngler appear in AR-specific searches but without local water depth data.</li>
       </ul>
     </div>
     <div class="report-block">
@@ -441,6 +439,9 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishbrain.com/shop" target="_blank">Fishbrain Marketplace &mdash; Shut Down (July 2026 check)</a></div>
     <div class="source-item"><a href="https://www.fishial.ai/" target="_blank">Fishial.AI &mdash; Photo Fish ID (powering GilledIt Q3 2026)</a></div>
     <div class="source-item"><a href="https://fishgpt.com/" target="_blank">FishGPT &mdash; AI Fishing Assistant (niche watch-list)</a></div>
+    <div class="source-item"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &mdash; New Paywalled Tier (July 2026)</a></div>
+    <div class="source-item"><a href="https://www.onxmaps.com/blog/onx-fish-expands-to-montana-for-lake-anglers" target="_blank">onX Fish &mdash; Expands to Montana (May 2026)</a></div>
+    <div class="source-item"><a href="https://www.pocketfishinguide.com/waters" target="_blank">pocketfishinguide.com/waters &mdash; PFG live site (now appearing in organic search)</a></div>
   </div>
 </div>
 
@@ -487,19 +488,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
     <div class="card">
       <div class="card-header" onclick="toggleDetails('d-fishangler')" style="cursor:pointer;">
-        <div><div class="card-title">FishAngler</div><div class="card-sub">100% Free &middot; 2.5M Community</div></div>
-        <span class="badge badge-amber">Watch</span>
+        <div><div class="card-title">FishAngler</div><div class="card-sub">Now Paywalled &middot; VIP Backlash</div></div>
+        <span class="badge badge-muted">Low Threat</span>
       </div>
       <div class="threat-meter">
-        <div class="threat-label"><span>Threat to PFG</span><span>Medium</span></div>
-        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:50%"></div></div>
+        <div class="threat-label"><span>Threat to PFG</span><span>Low&ndash;Medium (down from Medium)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:35%"></div></div>
       </div>
-      <div class="tags"><span class="tag">Free</span><span class="tag">Social</span><span class="tag">Solunar</span><span class="tag">2.5M Users</span></div>
+      <div class="tags"><span class="tag">VIP Paywall</span><span class="tag">Social</span><span class="tag">2.5M Users</span><span class="tag">Declining Sentiment</span></div>
       <div id="d-fishangler" class="details-panel">
-        <p><strong>What they do:</strong> Catch logbook, catch maps, 7-day weather, tidal updates, solunar forecast, social community &mdash; all free, no premium tier.</p>
-        <p style="margin-top:8px;"><strong>Threat:</strong> Completely free model directly competes with PFG&rsquo;s value proposition. Large community creates social flywheel.</p>
-        <p style="margin-top:8px;"><strong>PFG edge:</strong> Condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species &mdash; none of which FishAngler provides locally.</p>
-        <p style="margin-top:8px;"><a href="https://blog.fishangler.com" target="_blank">fishangler.com &#x2197;</a></p>
+        <p><strong>What they do:</strong> Catch logbook, catch maps, social community, plus a proprietary FishForecast&trade; layer &mdash; weather radar, feeding windows, 14-day outlook, exact location precision.</p>
+        <p style="margin-top:8px;"><strong>Update (July 2026):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Users are vocally unhappy &mdash; complaints center on losing features they&rsquo;d had for years. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Free forever, condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species. FishAngler&rsquo;s pivot is a live case study for PFG&rsquo;s free-core rubric (see Best Practices).</p>
+        <p style="margin-top:8px;"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &#x2197;</a></p>
       </div>
     </div>
 
@@ -698,7 +699,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <tr>
           <td class="feature-name">Free core (no paywall)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
         </tr>
@@ -1066,7 +1067,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">Free Core Model</div>
-      <div class="rubric-desc">Fishbrain&rsquo;s paywall is its #1 cited weakness in every 2026 review. GilledIt and FishAngler&rsquo;s free models drive faster growth. PFG&rsquo;s free-forever philosophy is strategically correct &mdash; monetize through donations, affiliates, and premium guides, not feature gating.</div>
+      <div class="rubric-desc">Fishbrain&rsquo;s paywall is its #1 cited weakness in every 2026 review. FishAngler just proved the same lesson live: it paywalled its FishForecast and location features behind a new VIP tier in July 2026 and is taking real user backlash for it. GilledIt&rsquo;s free model keeps growing. PFG&rsquo;s free-forever philosophy is strategically correct &mdash; monetize through donations, affiliates, and premium guides, not feature gating.</div>
       <div class="rubric-score score-a">A</div>
     </div>
     <div class="rubric-row">
@@ -1211,6 +1212,16 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.6 &middot; July 6, 2026</h3>
+    <ul>
+      <li><strong>FishAngler abandoned its free-core model,</strong> launching a &ldquo;VIP&rdquo; tier that paywalls FishForecast (feeding windows, 14-day outlook), the solunar calendar, and exact location data. Real user backlash reported. Threat to PFG downgraded Medium&rarr;Low-Medium; this is now cited as a live case study in the Best Practices free-core rubric.</li>
+      <li><strong>onX Fish</strong>&rsquo;s newest expansion (May 2026) went to Montana &mdash; its home state, and its first move beyond the Midwest &mdash; not south toward Arkansas. Missouri remains the nearest border state, unchanged; near-term AR threat trajectory is not accelerating this cycle.</li>
+      <li><strong>First PFG organic search signal:</strong> pocketfishinguide.com/waters now appears directly in web search results for &ldquo;Pocket Fishing Guide Arkansas app&rdquo;-style queries &mdash; it did not as of the July 2 scan. Still zero editorial, forum, or social mentions.</li>
+      <li>GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped. No new Arkansas-focused competitors or PFG clones detected.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.5 &middot; July 2, 2026</h3>


### PR DESCRIPTION
## Summary
Routine competitive/market intelligence scan for PocketFishingGuide, per the recurring monitoring cadence documented in the dashboard's own Best Practices tab. Updates `competitive-dashboard.html` from v1.5 (July 2) to v1.6 (July 6).

- **FishAngler abandoned its free-core model.** It launched a paywalled "VIP" tier gating FishForecast (feeding windows, 14-day outlook), the solunar calendar, and exact location data — and is drawing real user backlash for it. Threat rating downgraded Medium → Low-Medium; the pivot is now cited as a live case study in the Free Core Model rubric row.
- **onX Fish's latest expansion (Montana, May 2026)** went to its home state rather than south toward Arkansas. Missouri remains the nearest bordering state, unchanged — no acceleration of the AR threat timeline this cycle.
- **First organic search signal for PFG:** `pocketfishinguide.com/waters` now surfaces in web search for branded queries, which it did not as of the July 2 scan. Still zero editorial, forum, or social mentions.
- No new Arkansas-focused competitors or PFG clones detected. GilledIt's Fishial.AI photo ID remains on track for Q3 2026, unshipped.

Updated: header version/date, summary alert, Intelligence Report tab (new competitors + PFG mentions sections), FishAngler competitor card, feature matrix free-core row, Best Practices free-core rubric note, Sources list, and a new v1.6 entry in the append-only History tab.

## Test plan
- [x] Verified HTML parses cleanly (Node `readFileSync` + tag-balance check)
- [ ] Open `competitive-dashboard.html` in a browser and click through all 8 tabs, confirm the FishAngler card detail panel and new History entry render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By5pAsj9UdhD4mo1S1dvm7

---
_Generated by [Claude Code](https://claude.ai/code/session_01By5pAsj9UdhD4mo1S1dvm7)_