### PR TITLE
[Feature] PFG competitive intelligence dashboard — July 8 scan (v1.7)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 6, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.6</div>
+    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">11</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
-  <div class="stat"><span class="stat-val">50.1M</span><span class="stat-label">US Anglers</span></div>
-  <div class="stat"><span class="stat-val">45%</span><span class="stat-label">Use Mobile Apps</span></div>
+  <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
+  <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> FishAngler &mdash; previously tagged 100% free &mdash; just launched a paywalled &ldquo;VIP&rdquo; tier gating forecasts and location data, and is drawing real user backlash. PFG&rsquo;s free-core bet looks stronger. onX Fish&rsquo;s latest expansion went to Montana (home turf), not south toward AR; Missouri is still the nearest border, unchanged. PFG&rsquo;s own site is now surfacing in organic search for branded queries &mdash; a first, though still no editorial or community mentions.
+    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -345,46 +345,55 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="report-block">
       <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
       <ul>
-        <li><strong>No direct Arkansas-focused clones detected.</strong> PFG&rsquo;s hyper-local depth remains unchallenged at the state level.</li>
-        <li><strong>FishAngler pulled back from its free model.</strong> It launched a &ldquo;FishAngler VIP&rdquo; tier gating its FishForecast (feeding windows, 14-day outlook), solunar calendar, and exact location data &mdash; the exact features that made it a free-model threat. User sentiment has turned sharply negative over the paywall plus a confusing UI redesign.</li>
-        <li><strong>onX Fish</strong> expanded to Montana (May 2026) &mdash; its first move beyond the Midwest, and notably its home state (onX is HQ&rsquo;d in Missoula), not a push south toward Arkansas. Still 11 states at $34.99/yr; Missouri remains the nearest border, unchanged since the last scan.</li>
-        <li><strong>GilledIt</strong>&rsquo;s Fishial.AI-powered photo fish ID remains slated for Q3 2026 &mdash; not yet shipped, no change since last scan.</li>
+        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
+        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
+        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
+        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
+        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>First organic search signal:</strong> pocketfishinguide.com/waters now surfaces directly in Google results for &ldquo;Pocket Fishing Guide Arkansas app&rdquo;-style queries. It didn&rsquo;t as of the July 2 scan &mdash; the site is starting to get indexed.</li>
+        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
         <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li>Still no Reddit threads, fishing forum posts, or social media mentions found for &ldquo;Pocket Fishing Guide.&rdquo;</li>
         <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>onWater Fish</strong> covers Arkansas water maps but lacks condition-aware lure scoring or spawn phase tracking.</li>
+        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Education:</strong> BassForecast now bundles Bass University with PRO. GilledIt uses challenges and badges for progression. Both validate PFG&rsquo;s planned education tier.</li>
-        <li><strong>AI assistant:</strong> Fishbox launched a plain-English AI catch assistant. PFG&rsquo;s Claude API roadmap item is more powerful &mdash; condition-aware and AR-specific.</li>
+        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint now reaches Missouri, directly on Arkansas&rsquo;s border. PFG&rsquo;s PWA + install prompts are the bridge before a funded competitor arrives.</li>
-        <li><strong>Hardware integration:</strong> Sonar+GPS app integrations grew 33% across active apps. Low priority for PFG&rsquo;s segment.</li>
+        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall is the most-cited negative across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Beginners underserved:</strong> Only Fishbox explicitly targets new anglers. PFG&rsquo;s education roadmap addresses the largest untapped segment.</li>
-        <li><strong>Local depth wins:</strong> No national app covers 39 Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring. This is PFG&rsquo;s structural moat.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction.</li>
-        <li><strong>Paddler/kayak crossover:</strong> PFG&rsquo;s Paddler feature fills a niche no major fishing app serves.</li>
+        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
+        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
+        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
+        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
+        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
       </ul>
     </div>
   </div>
 
   <div class="section-title"><span class="icon">&#x1F4CB;</span>Top Recommendations</div>
+  <div class="opp-card priority-high">
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
+    <div class="opp-content">
+      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
+      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
+    </div>
+  </div>
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">1</div>
     <div class="opp-content">
@@ -442,6 +451,14 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &mdash; New Paywalled Tier (July 2026)</a></div>
     <div class="source-item"><a href="https://www.onxmaps.com/blog/onx-fish-expands-to-montana-for-lake-anglers" target="_blank">onX Fish &mdash; Expands to Montana (May 2026)</a></div>
     <div class="source-item"><a href="https://www.pocketfishinguide.com/waters" target="_blank">pocketfishinguide.com/waters &mdash; PFG live site (now appearing in organic search)</a></div>
+    <div class="source-item"><a href="https://outdoorindustry.org/press-release/onwater-fish-launches-angler-intelligence-the-first-ai-native-fishing-experience-in-outdoor-recreation/" target="_blank">Outdoor Industry Association &mdash; onWater Fish Launches Angler Intelligence&trade;</a></div>
+    <div class="source-item"><a href="https://www.businesswire.com/news/home/20250602251753/en/onWater-Fish-App-Launches-Next-Gen-Tools-to-Power-the-Future-of-Angling" target="_blank">BusinessWire &mdash; onWater AI Trout Measuring Tool (beta)</a></div>
+    <div class="source-item"><a href="https://www.onwaterapp.com/features/angler-intelligence" target="_blank">onWater Fish &mdash; Angler Intelligence feature page</a></div>
+    <div class="source-item"><a href="https://apps.apple.com/us/app/fishing-app-fishguide-ai/id6747693672" target="_blank">FishGuide AI &mdash; App Store (v2.0, Ice Fishing Mode, Bite Times)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.fishai.app" target="_blank">Fish AI &mdash; Google Play (leaderboards added July 5, 2026)</a></div>
+    <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
+    <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
+    <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
   </div>
 </div>
 
@@ -611,19 +628,55 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
     <div class="card">
       <div class="card-header" onclick="toggleDetails('d-onwater')" style="cursor:pointer;">
-        <div><div class="card-title">onWater Fish</div><div class="card-sub">AR Water Maps &middot; Access Points</div></div>
+        <div><div class="card-title">onWater Fish</div><div class="card-sub">&ldquo;AI-Native&rdquo; &middot; Live in Arkansas Today</div></div>
+        <span class="badge badge-red">Monitor &mdash; Top Threat</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>High &mdash; positioning collision, live in AR now</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-high" style="width:75%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">AI-Native</span><span class="tag">AI Trout Measuring</span><span class="tag">AR Lakes/Rivers</span><span class="tag">Species Maps</span></div>
+      <div id="d-onwater" class="details-panel">
+        <p><strong>What they do:</strong> Browse rivers/lakes across Arkansas, boat ramps, species habitat maps &mdash; plus, new as of this scan, &ldquo;Angler Intelligence&trade;&rdquo; (launched Oct 24, 2025), marketed as &ldquo;the First AI-Native Fishing Experience.&rdquo; Includes a patented AI Trout Measuring Tool (beta) that IDs fish from a photo across 107 species and returns length/weight with no reference object needed, built on live gauge/weather/access data.</p>
+        <p style="margin-top:8px;"><strong>Escalation (July 2026):</strong> This was missed in earlier scans and is now the closest positioning match found to date &mdash; &ldquo;AI-native&rdquo; is near-identical language to how PFG describes itself, and onWater is already live in Arkansas, not a future risk. Unverified: whether its Arkansas data has AGFC-level depth or is the same shallow national-database coverage seen elsewhere. Needs a direct hands-on check.</p>
+        <p style="margin-top:8px;"><strong>PFG edge (if depth checks out as shallow):</strong> Condition-aware lure scoring, spawn phase tracking, AGFC-cited reports &mdash; a specific intelligence layer vs. onWater&rsquo;s general-purpose AI Q&amp;A and photo ID.</p>
+        <p style="margin-top:8px;"><a href="https://www.onwaterapp.com/state/arkansas" target="_blank">onwaterapp.com/arkansas &#x2197;</a> &middot; <a href="https://www.onwaterapp.com/features/angler-intelligence" target="_blank">Angler Intelligence &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-fishguideai')" style="cursor:pointer;">
+        <div><div class="card-title">FishGuide AI</div><div class="card-sub">AI Cast Guidance &middot; v2.0 Shipped</div></div>
         <span class="badge badge-amber">Watch</span>
       </div>
       <div class="threat-meter">
-        <div class="threat-label"><span>Threat to PFG</span><span>Medium (AR water overlap)</span></div>
-        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:40%"></div></div>
+        <div class="threat-label"><span>Threat to PFG</span><span>Medium&ndash;High (closest functional overlap)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:60%"></div></div>
       </div>
-      <div class="tags"><span class="tag">AR Lakes/Rivers</span><span class="tag">Boat Ramps</span><span class="tag">Water Layers</span><span class="tag">Species Maps</span></div>
-      <div id="d-onwater" class="details-panel">
-        <p><strong>What they do:</strong> Browse rivers/lakes across Arkansas, check public-land access, boat ramps, water condition layers, species habitat maps.</p>
-        <p style="margin-top:8px;"><strong>Overlap:</strong> Covers similar AR water bodies but lacks condition-aware lure intelligence, spawn phase tracking, and real-time USGS scoring.</p>
-        <p style="margin-top:8px;"><strong>PFG edge:</strong> Intelligence vs. maps. PFG tells you what to throw and when; onWater shows you where to go. Potentially complementary rather than competitive.</p>
-        <p style="margin-top:8px;"><a href="https://www.onwaterapp.com/state/arkansas" target="_blank">onwaterapp.com/arkansas &#x2197;</a></p>
+      <div class="tags"><span class="tag">Daily Bite Score</span><span class="tag">Ice Fishing Mode</span><span class="tag">10-Day Forecast</span><span class="tag">All Species</span></div>
+      <div id="d-fishguideai" class="details-panel">
+        <p><strong>What they do:</strong> AI-powered assistant for lakes, ponds, rivers, streams &mdash; minimal inputs, returns specific guidance on where to cast, what lure, what depth. v2.0 (shipped this window) added Ice Fishing Mode, a Daily Bite Score (1&ndash;100, 10-day forecast), and a new Bite Times feature.</p>
+        <p style="margin-top:8px;"><strong>Overlap:</strong> Clearest functional match to PFG&rsquo;s core &ldquo;what to throw and when&rdquo; concept found among any competitor. No Arkansas-specific angle identified yet.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> AGFC-cited, real-time USGS/NWS data, spawn phase tracking for named AR species &mdash; FishGuide AI is generic/national, not locally sourced.</p>
+        <p style="margin-top:8px;"><a href="https://apps.apple.com/us/app/fishing-app-fishguide-ai/id6747693672" target="_blank">App Store &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-fishtips')" style="cursor:pointer;">
+        <div><div class="card-title">FishTips</div><div class="card-sub">Arkansas Digital Guides &middot; Subscription</div></div>
+        <span class="badge badge-amber">Watch</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>Medium (direct AR overlap, no AI/data)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:45%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">AR-Specific</span><span class="tag">Guide-Authored</span><span class="tag">Subscription</span><span class="tag">No Real-Time Data</span></div>
+      <div id="d-fishtips" class="details-panel">
+        <p><strong>What they do:</strong> Atlanta-based digital-guide platform with dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River &mdash; local reports, instructional video, and guide profiles. Premium subscription channels for hyper-current intel from &ldquo;digital guides.&rdquo;</p>
+        <p style="margin-top:8px;"><strong>Overlap:</strong> Community/local-intelligence angle partially overlaps with PFG&rsquo;s local depth, and it is Arkansas-specific. Content is guide-contributed, not data-driven &mdash; no AI, no real-time USGS/NWS/AGFC integration.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Free, real-time condition-aware scoring vs. FishTips&rsquo; paid, human-authored reports. Potentially a partnership target (guide content) rather than a pure competitor.</p>
+        <p style="margin-top:8px;"><a href="https://fishtips.com/states/arkansas" target="_blank">fishtips.com/states/arkansas &#x2197;</a></p>
       </div>
     </div>
 
@@ -661,6 +714,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <th>Fishbrain</th>
           <th>FishAngler</th>
           <th>onX Fish</th>
+          <th>onWater Fish</th>
           <th>Omnia</th>
           <th>BassForecast</th>
           <th>Fishbox</th>
@@ -672,105 +726,105 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <td class="feature-name">Arkansas-specific depth (39+ waters)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
         </tr>
         <tr>
           <td class="feature-name">Real-time USGS / NWS data</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Condition-aware lure scoring</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Spawn phase tracking</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Free core (no paywall)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Zero backend / GitHub Pages</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Community / social catch log</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">AI fishing assistant</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Education / skill progression</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Gamification (badges / challenges)</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Paddler / kayak mode</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">PWA / mobile install</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Bathymetric maps</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Hardware (sonar/GPS) integration</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Weekly digest / fishing reports</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
       </tbody>
@@ -810,26 +864,27 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <h3>Angler Behavior &amp; Technology Adoption</h3>
       <div class="bar-chart" style="margin-top:12px;">
         <div class="bar-row">
-          <div class="bar-name">US Anglers (active)</div>
-          <div class="bar-track"><div class="bar-fill" data-width="50%" style="width:0; background:var(--green);">50.1M</div></div>
+          <div class="bar-name">US Anglers 2024 (record high)</div>
+          <div class="bar-track"><div class="bar-fill" data-width="58%" style="width:0; background:var(--green);">57.9M</div></div>
         </div>
         <div class="bar-row">
-          <div class="bar-name">Use mobile apps</div>
-          <div class="bar-track"><div class="bar-fill" data-width="45%" style="width:0; background:var(--navy-light);">45%</div></div>
+          <div class="bar-name">Participation rate</div>
+          <div class="bar-track"><div class="bar-fill" data-width="19%" style="width:0; background:var(--navy-light);">19%</div></div>
         </div>
         <div class="bar-row">
-          <div class="bar-name">App downloads &#x2191; recent</div>
-          <div class="bar-track"><div class="bar-fill" data-width="62%" style="width:0; background:var(--amber);">+62%</div></div>
+          <div class="bar-name">One-year angler churn</div>
+          <div class="bar-track"><div class="bar-fill" data-width="23%" style="width:0; background:var(--red);">23%</div></div>
         </div>
         <div class="bar-row">
-          <div class="bar-name">AI feature adoption &#x2191;</div>
-          <div class="bar-track"><div class="bar-fill" data-width="38%" style="width:0; background:var(--partial);">+38%</div></div>
+          <div class="bar-name">Fished 1+&times;/month (down from 37%)</div>
+          <div class="bar-track"><div class="bar-fill" data-width="32%" style="width:0; background:var(--amber);">32%</div></div>
         </div>
         <div class="bar-row">
-          <div class="bar-name">Apps w/ hardware integration</div>
-          <div class="bar-track"><div class="bar-fill" data-width="33%" style="width:0; background:var(--navy-light);">33%</div></div>
+          <div class="bar-name">Female youth churn vs. male</div>
+          <div class="bar-track"><div class="bar-fill" data-width="11%" style="width:0; background:var(--partial);">+11pt</div></div>
         </div>
       </div>
+      <div style="font-size:11px; color:var(--text-muted); margin-top:12px;">Source: RBFF/ASA 2025 Special Report on Fishing. 85% of anglers started before age 12; participation drops sharply after 18. Retention/onboarding is a real, data-backed growth lever &mdash; not just a nice-to-have.</div>
     </div>
   </div>
 
@@ -844,8 +899,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div style="font-size:12px; color:var(--text-muted);">Fishbrain&rsquo;s paywall is its biggest cited weakness. GilledIt and FishAngler are entirely free and growing fastest. PFG&rsquo;s free model aligns with this trend. Ko-fi, Patreon, and affiliate monetization are the right path forward &mdash; not feature gating.</div>
     </div>
     <div class="card">
-      <div class="card-title" style="color:var(--soon); margin-bottom:8px;">Platform expansion is accelerating</div>
-      <div style="font-size:12px; color:var(--text-muted);">onX Fish Midwest&rsquo;s Android launch (May 2026) shows well-funded outdoor platforms expanding state coverage rapidly. PFG&rsquo;s Arkansas moat is durable today &mdash; the window to build community before a national player arrives is approximately 12&ndash;18 months.</div>
+      <div class="card-title" style="color:var(--soon); margin-bottom:8px;">The window just got shorter</div>
+      <div style="font-size:12px; color:var(--text-muted);">onX Fish is still 12&ndash;18 months out on Arkansas specifically, but onWater Fish and FishTips are already live in-state today. PFG&rsquo;s Arkansas moat is real but no longer uncontested &mdash; the priority is verifying onWater&rsquo;s actual AR data depth and moving on editorial/AGFC visibility now, not later.</div>
     </div>
     <div class="card">
       <div class="card-title" style="color:var(--green-light); margin-bottom:8px;">Outdoor market: $152B and growing</div>
@@ -865,11 +920,12 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="report-block">
     <h3>Who else covers Arkansas waters?</h3>
     <ul>
+      <li><strong>onWater Fish</strong> &mdash; Now the sharpest overlap: live AR pages plus &ldquo;Angler Intelligence&trade;&rdquo; AI photo ID and fish measuring. Data depth on Arkansas specifically is unverified &mdash; top-priority item to check directly.</li>
+      <li><strong>FishTips</strong> &mdash; Arkansas-specific, guide-authored reports (Lake Erling, Lake Conway, Arkansas River, Spring River) behind a subscription. No AI, no real-time USGS/NWS/AGFC data.</li>
       <li><strong>AGFC Mobile</strong> &mdash; Official state app for licensing only. No fishing intelligence. Highest-value partner target.</li>
-      <li><strong>onWater Fish</strong> &mdash; Maps, access points, species habitat layers for AR. No real-time conditions or lure scoring.</li>
       <li><strong>Fishbrain / FishAngler</strong> &mdash; Cover AR in national databases. No local depth, no USGS integration, no spawn phase data for AR species.</li>
       <li><strong>Omnia Fishing</strong> &mdash; Crowd-sourced reports for some AR lakes. Shallow vs. PFG&rsquo;s 39-body real-time database.</li>
-      <li><strong>No dedicated Arkansas fishing intelligence app exists outside PFG.</strong> This is the structural moat.</li>
+      <li><strong>No competitor yet combines real-time USGS/NWS data, condition-aware lure scoring, and AGFC-cited reports for Arkansas.</strong> This is PFG&rsquo;s structural moat &mdash; now contested on positioning, not yet on data depth.</li>
     </ul>
   </div>
 </div>
@@ -909,7 +965,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="canvas-cell span2">
       <div class="canvas-label">Unfair Advantage</div>
       <ul>
-        <li><strong>Local field knowledge</strong> no national team can replicate quickly</li>
+        <li><strong>Local field knowledge</strong> no national team can replicate quickly &mdash; incl. onWater Fish&rsquo;s AI-native positioning, whose Arkansas data depth is unverified</li>
         <li>USGS/NWS real-time integration &mdash; novel at state depth level</li>
         <li>Open-source, community-trusted &mdash; no VC pressure or paywall mandate</li>
         <li>Founder credibility: AR-native angler + CRM/marine tech background</li>
@@ -976,6 +1032,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">1</div>
     <div class="opp-content">
+      <div class="opp-title">Verify onWater Fish&rsquo;s Actual Arkansas Depth</div>
+      <div class="opp-desc">onWater Fish now markets &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; and already has live Arkansas pages. Before reacting further, do a direct hands-on comparison: open onWater on an Arkansas water and check for AGFC-cited data, spawn-phase tracking, and condition-aware scoring versus PFG. This single check determines whether the rest of this list should accelerate.</div>
+      <div class="opp-meta">
+        <span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span><span class="badge badge-muted">0 Cost</span>
+        <a href="https://www.onwaterapp.com/state/arkansas" target="_blank" class="badge badge-blue" style="text-decoration:none;">onWater AR &#x2197;</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="opp-card priority-high">
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">2</div>
+    <div class="opp-content">
       <div class="opp-title">Editorial Discovery &mdash; Enter the 2026 Roundups</div>
       <div class="opp-desc">PFG is invisible in editorial fishing app lists that drive organic discovery. FishingBooker, Wired2Fish, Guidesly, and Kayak Angler Mag collectively reach hundreds of thousands of anglers. One inclusion changes visibility fundamentally. Write a one-page pitch emphasizing free, Arkansas-specific, real-time USGS data. Target fishing editors directly.</div>
       <div class="opp-meta">
@@ -987,7 +1055,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-high">
-    <div class="opp-num" style="background:rgba(192,57,43,0.3)">2</div>
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">3</div>
     <div class="opp-content">
       <div class="opp-title">PWA + App Store Distribution</div>
       <div class="opp-desc">Anglers search app stores first. A Google Play listing (via TWA/Bubblewrap) makes PFG findable to the 45% of US anglers who use mobile apps. The PWA manifest is already roadmapped &mdash; prioritize as a distribution unlock, not just a UX improvement. iOS App Store follows the same pattern.</div>
@@ -998,10 +1066,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-high">
-    <div class="opp-num" style="background:rgba(192,57,43,0.3)">3</div>
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">4</div>
     <div class="opp-content">
       <div class="opp-title">AGFC Partnership / Referral</div>
-      <div class="opp-desc">The Arkansas Game and Fish Commission&rsquo;s mobile app covers licensing only &mdash; no intelligence layer. Reaching out to AGFC&rsquo;s digital team for a mutual referral costs nothing and taps their existing angler audience directly. Credibility from an official AR state nod is significant and hard to replicate.</div>
+      <div class="opp-desc">The Arkansas Game and Fish Commission&rsquo;s mobile app covers licensing only &mdash; no intelligence layer. Reaching out to AGFC&rsquo;s digital team for a mutual referral costs nothing and taps their existing angler audience directly. Credibility from an official AR state nod is significant and hard for onWater Fish or FishTips to replicate quickly.</div>
       <div class="opp-meta">
         <span class="badge badge-red">High Priority</span><span class="badge badge-muted">Partnership</span><span class="badge badge-muted">0 Cost</span>
         <a href="https://www.agfc.com" target="_blank" class="badge badge-blue" style="text-decoration:none;">AGFC &#x2197;</a>
@@ -1010,10 +1078,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-med">
-    <div class="opp-num" style="background:rgba(243,156,18,0.3)">4</div>
+    <div class="opp-num" style="background:rgba(243,156,18,0.3)">5</div>
     <div class="opp-content">
       <div class="opp-title">Ship Education Layer Before National Competition Arrives</div>
-      <div class="opp-desc">BassForecast + Bass University, GilledIt badges/challenges, and Fishbox&rsquo;s AI chat all signal the market moving toward skill development. PFG&rsquo;s condition-aware lure scoring is already a teaching tool &mdash; frame it as such. Add &ldquo;why this lure?&rdquo; explanations to scored recommendations. No national app does this for Arkansas specifically. Window: 12&ndash;18 months.</div>
+      <div class="opp-desc">BassForecast + Bass University, GilledIt badges/challenges, Fish AI&rsquo;s new leaderboards, and Fishbox&rsquo;s AI chat all signal the market racing toward gamification, not education. No competitor &mdash; including onWater Fish, FishGuide AI, and FishTips &mdash; has shipped a true beginner&rarr;expert learning arc. PFG&rsquo;s condition-aware lure scoring is already a teaching tool &mdash; frame it as such. Add &ldquo;why this lure?&rdquo; explanations to scored recommendations. This white space is now PFG&rsquo;s cleanest differentiator against the field.</div>
       <div class="opp-meta">
         <span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Product</span><span class="badge badge-muted">Roadmap Item</span>
       </div>
@@ -1021,7 +1089,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-med">
-    <div class="opp-num" style="background:rgba(243,156,18,0.3)">5</div>
+    <div class="opp-num" style="background:rgba(243,156,18,0.3)">6</div>
     <div class="opp-content">
       <div class="opp-title">Paddler / Kayak Fishing Niche</div>
       <div class="opp-desc">Zero major fishing apps have a dedicated paddler/kayak mode. PFG&rsquo;s Paddler feature in development is a first-mover opportunity in one of the fastest-growing sub-segments of recreational fishing. Partner with Arkansas kayak fishing groups and outfitters to validate and promote this feature at launch.</div>
@@ -1032,7 +1100,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-med">
-    <div class="opp-num" style="background:rgba(243,156,18,0.3)">6</div>
+    <div class="opp-num" style="background:rgba(243,156,18,0.3)">7</div>
     <div class="opp-content">
       <div class="opp-title">Affiliate Commerce &mdash; Lure Link Monetization</div>
       <div class="opp-desc">Omnia Fishing&rsquo;s &ldquo;shop by lake&rdquo; model proves anglers buy tackle from in-app recommendations. PFG&rsquo;s lure scoring engine already recommends specific lures by condition &mdash; adding affiliate links to Omnia Fishing, Tackle Warehouse, or Amazon Associates converts recommendations into revenue. Low implementation cost, natural extension of what&rsquo;s already there.</div>
@@ -1044,10 +1112,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
 
   <div class="opp-card priority-low">
-    <div class="opp-num" style="background:rgba(143,163,184,0.2)">7</div>
+    <div class="opp-num" style="background:rgba(143,163,184,0.2)">8</div>
     <div class="opp-content">
       <div class="opp-title">Weekly Friday Fishing Report Email</div>
-      <div class="opp-desc">Fishbrain and BassForecast use weekly digests for retention. PFG&rsquo;s roadmap includes EmailJS-based weekly reports. This builds the habit loop. Automated LLM-generated narrative reports (roadmap: Intelligence &amp; Automation phase) make this nearly zero marginal cost at scale.</div>
+      <div class="opp-desc">Fishbrain and BassForecast use weekly digests for retention. PFG&rsquo;s roadmap includes EmailJS-based weekly reports. This builds the habit loop and speaks directly to the 23% one-year angler churn rate. Automated LLM-generated narrative reports (roadmap: Intelligence &amp; Automation phase) make this nearly zero marginal cost at scale.</div>
       <div class="opp-meta">
         <span class="badge badge-muted">Lower Priority</span><span class="badge badge-muted">Retention</span><span class="badge badge-muted">Roadmap Item</span>
       </div>
@@ -1083,6 +1151,11 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="rubric-row">
       <div class="rubric-name">Onboarding &amp; Education</div>
       <div class="rubric-desc">Fishbox&rsquo;s AI assistant and GilledIt&rsquo;s challenge system show beginners need guided onboarding. PFG&rsquo;s condition-aware lure scoring is powerful but not yet presented as a learning tool. Add &ldquo;why this lure?&rdquo; context to existing scored recommendations as a first step.</div>
+      <div class="rubric-score score-c">C</div>
+    </div>
+    <div class="rubric-row">
+      <div class="rubric-name">AI-Native Differentiation</div>
+      <div class="rubric-desc">onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products, and onWater&rsquo;s &ldquo;AI-native&rdquo; branding is near-identical to PFG&rsquo;s own language. PFG&rsquo;s planned Claude API assistant needs a specific, defensible angle &mdash; AGFC-cited, condition-aware, Arkansas-only &mdash; to avoid reading as one more generic AI fishing chatbot once it ships.</div>
       <div class="rubric-score score-c">C</div>
     </div>
     <div class="rubric-row">
@@ -1184,8 +1257,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <ul style="padding-left:16px; margin-top:8px;">
           <li><strong>Monthly:</strong> Search PFG mentions, fishing forum mentions, editorial updates. ~30 minutes.</li>
           <li><strong>Quarterly:</strong> Full feature matrix refresh. Check GilledIt, Fishbrain, onX Fish, Fishbox for new features.</li>
-          <li><strong>Trigger:</strong> When a national app announces Arkansas expansion &mdash; accelerate community and editorial outreach immediately. onX Fish is the one to watch.</li>
-          <li><strong>Sources to monitor:</strong> <a href="https://www.wired2fish.com" target="_blank">Wired2Fish</a> &middot; <a href="https://fishbrain.com/blog/general/whats-new-on-fishbrain" target="_blank">Fishbrain What&rsquo;s New</a> &middot; Google Play release notes for onX Fish, GilledIt</li>
+          <li><strong>Trigger:</strong> When a national app announces Arkansas expansion &mdash; accelerate community and editorial outreach immediately. <strong>onWater Fish and FishTips are already live in Arkansas</strong>; onX Fish remains the longer-horizon watch item.</li>
+          <li><strong>Sources to monitor:</strong> <a href="https://www.wired2fish.com" target="_blank">Wired2Fish</a> &middot; <a href="https://fishbrain.com/blog/general/whats-new-on-fishbrain" target="_blank">Fishbrain What&rsquo;s New</a> &middot; <a href="https://www.onwaterapp.com/state/arkansas" target="_blank">onWater Fish Arkansas</a> &middot; Google Play release notes for onX Fish, GilledIt, Fish AI</li>
         </ul>
       </div>
     </div>
@@ -1212,6 +1285,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.7 &middot; July 8, 2026</h3>
+    <ul>
+      <li><strong>onWater Fish escalated from Medium/Watch to High/Monitor &mdash; PFG&rsquo;s sharpest positioning collision to date.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025), including a patented AI Trout Measuring Tool (beta) that IDs fish and measures length/weight from a photo, no reference object needed, across 107 species. It already runs dedicated Arkansas pages today, not a future risk, and its &ldquo;AI-native&rdquo; self-description is near-identical to PFG&rsquo;s own language. Its Arkansas data depth is unverified &mdash; a direct hands-on comparison is now the top-priority action item, added as Opportunity #1.</li>
+      <li><strong>Two competitors added to tracking:</strong> FishGuide AI (App Store; shipped v2.0 this window &mdash; Ice Fishing Mode, Daily Bite Score 1&ndash;100 with 10-day forecast, Bite Times &mdash; closest functional overlap with PFG&rsquo;s core concept found to date) and Fish AI (Google Play; added global leaderboards July 5, 2026; mixed sentiment on fish-ID speed and subscription practices).</li>
+      <li><strong>FishTips added</strong> &mdash; an Arkansas-specific, guide-authored, subscription digital-guide platform (Lake Erling, Lake Conway, Arkansas River, Spring River). No AI or real-time data, but a direct AR-market competitor that had gone untracked. 13 competitors now tracked, up from 11.</li>
+      <li><strong>Feature Matrix</strong> gained an onWater Fish column across all 15 feature rows.</li>
+      <li><strong>Market data refreshed from the RBFF/ASA 2025 Special Report on Fishing:</strong> 57.9M US anglers in 2024 (record high, 19% participation) alongside a 23% one-year churn rate (16.6M anglers lost), with female youth quitting at an 11-point higher rate than male youth after 18. Reframes PFG&rsquo;s planned retention/onboarding work as a data-backed growth lever, not just polish.</li>
+      <li><strong>PFG mentions unchanged:</strong> public site remains Google-indexed (first-party only); zero third-party mentions across Reddit, X, forums, press, or app stores. Visibility gap is widening, not narrowing, as onWater Fish and FishTips both now out-rank PFG for Arkansas fishing-app queries.</li>
+      <li>Best Practices gained an &ldquo;AI-Native Differentiation&rdquo; rubric row (C) given the new AI-forward competitor cluster.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.6 &middot; July 6, 2026</h3>


### PR DESCRIPTION
## Summary

Routine competitive-monitoring scan for `competitive-dashboard.html` (v1.6 → v1.7). The headline finding: **onWater Fish** has escalated from a background "watch" item to PFG's sharpest positioning collision — it launched "Angler Intelligence™ — the First AI-Native Fishing Experience" (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today (not a future risk).

- Escalates onWater Fish from Medium/Watch to High/Monitor, with detail on its AI-native positioning and AI trout-measuring tool; data depth on Arkansas specifically is flagged as unverified and added as the #1 opportunity ("verify onWater's actual Arkansas depth" before reacting further)
- Adds two newly tracked competitors: **FishGuide AI** (shipped v2.0 — Ice Fishing Mode, Daily Bite Score, Bite Times) and **FishTips** (Arkansas-specific guide-authored subscription platform) — 13 tracked competitors, up from 11
- Extends the Feature Matrix with an onWater Fish column across all 15 feature rows
- Refreshes market data from the 2025 RBFF/ASA Special Report on Fishing (57.9M anglers, 19% participation, 23% one-year churn) — reframes PFG's planned retention/onboarding work as a data-backed growth lever
- Updates Best Practices with a new "AI-Native Differentiation" rubric row given the new AI-forward competitor cluster
- Appends a v1.7 entry to the History tab per the dashboard's append-only scan-log convention

PFG's own visibility is unchanged this scan: site remains Google-indexed (first-party only), zero third-party mentions found anywhere.

## Test plan

- [x] Verified table structure: all 15 Feature Matrix rows now have 11 `<td>` cells (Feature + PFG + 9 competitors), matching the header row
- [x] Verified all 13 competitor cards have unique `id`s and no duplicate `toggleDetails()` targets
- [x] Verified balanced `<div>` open/close tag counts across the file
- [ ] Visual check in browser (no build step — static HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWW4PtFhJ3vzK2Av4cAxzL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWW4PtFhJ3vzK2Av4cAxzL)_