### PR TITLE
[Chore] Competitive dashboard v1.8 — July 9, 2026 scan

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 9, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> Quiet cycle &mdash; no new competitors, no PFG clones, and no third-party PFG mentions found. The one confirmed move is <strong>Fishbrain</strong> shipping a Garmin HD depth-chart layer and a Parks &amp; Government Lands access layer (both Pro-gated), reinforcing its paywall-heavy but improving map utility. <strong>onWater Fish&rsquo;s Arkansas data-depth verification (flagged as Opportunity #1 in the last scan) is still outstanding</strong> &mdash; it remains the top open action item, not a new one.
   </div>
 </div>
 
@@ -343,43 +343,40 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 9 Update</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>Quiet cycle &mdash; no new competitors or clones identified.</strong> All 13 tracked apps and categories were rechecked; none show a new Arkansas move this window. This is a rescan, not a new baseline &mdash; treat the absence of news as confirmation, not as reduced risk on the open items below.</li>
+        <li><strong>onWater Fish, FishGuide AI, and FishTips (added last scan) are unchanged this window.</strong> onWater&rsquo;s Arkansas data-depth verification, flagged as the #1 opportunity on July 8, was not yet performed &mdash; it carries forward as this scan&rsquo;s top open item rather than a fresh finding.</li>
+        <li><strong>FishAngler&rsquo;s VIP paywall backlash has deepened, not just persisted.</strong> A third-party sentiment source (marlvel.ai) corroborates declining sentiment and adds detail: users describe the change as developers &ldquo;gaslighting&rdquo; them about feature removal, and separate technical-trust complaints (fake profiles, upload loops) are compounding the paywall anger.</li>
+        <li><strong>onX Fish</strong>&rsquo;s footprint remains Montana/Missouri &mdash; no further movement toward Arkansas. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
+        <li><strong>Unchanged since July 8.</strong> pocketfishinguide.com remains Google-indexed (first-party only). Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings again returned zero third-party results for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup (FishingBooker, Hook &amp; Barrel, Kayak Angler, Fishbox, Guidesly, Wired2Fish all rechecked this window).</li>
         <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li>Note: pocketfishinguide.com&rsquo;s own landing copy surfaced in search includes claims (funding raised, app-store category ranking) that read as placeholder/aspirational marketing text rather than verified facts &mdash; worth a quick internal check that public-facing copy matches reality, separate from this competitive scan.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
+        <li><strong>Fishbrain shipped two new Pro-gated map layers this window:</strong> Garmin-powered HD depth charts (0.5m accuracy) and a Parks &amp; Government Lands layer that highlights public-land parcels and access boundaries across the map. Both reinforce Fishbrain&rsquo;s paywall-heavy but increasingly capable mapping stack &mdash; a genuine utility upgrade, not just a retention gimmick.</li>
+        <li><strong>Public-land / access-point data is a gap on PFG&rsquo;s own roadmap</strong> worth noting given Fishbrain&rsquo;s move &mdash; bank/wade/kayak anglers (PFG&rsquo;s core user) care about legal access as much as conditions.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI remain the live AI-forward products to watch. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
+        <li><strong>Paywalls remain the top complaint, and FishAngler&rsquo;s is worsening.</strong> Third-party sentiment analysis this window adds specific complaint language (&ldquo;gaslighting,&rdquo; fake profiles, upload loops) beyond the general paywall backlash noted last scan. PFG&rsquo;s free model is a genuine, widening differentiator.</li>
+        <li><strong>Record participation, record churn</strong> (RBFF/Outdoor Foundation, unchanged this window): 57.9M Americans fished in 2024, 23% one-year churn. Still a strong signal for retention-focused UX already on PFG&rsquo;s roadmap.</li>
+        <li><strong>Local depth wins &mdash; but the field is more crowded than a quiet news week suggests.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. The onWater Arkansas-depth verification remains unperformed and is the highest-value open task from this dashboard.</li>
         <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
       </ul>
     </div>
@@ -389,8 +386,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; still outstanding, second scan running</div>
+      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. This was flagged as the top priority on July 8 and remains undone as of July 9 &mdash; a competitive scan can surface the signal but can&rsquo;t substitute for the 30-minute hands-on check. Spend it in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG before this carries to a third scan.</div>
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
     </div>
   </div>
@@ -459,6 +456,11 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://fishbrain.com/blog/fishbrain/new-feature-announcement-navionics-depth-charts" target="_blank">Fishbrain &mdash; Garmin/Navionics HD Depth Charts (Pro)</a></div>
+    <div class="source-item"><a href="https://fishbrain.helpshift.com/hc/en/3-fishbrain---social-fishing-forecast-app/faq/469-how-can-i-use-the-parks-government-land-map-layer-in-fishbrain/" target="_blank">Fishbrain &mdash; Parks &amp; Government Land Map Layer (Pro)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel.ai &mdash; FishAngler Sentiment &amp; Intel Report (July 2026)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/apps/com-fishai-app" target="_blank">Marlvel.ai &mdash; Fish AI Sentiment &amp; Intel Report (July 2026)</a></div>
+    <div class="source-item"><a href="https://www.hookandbarrel.com/gear/hunting-and-fishing-apps-2026" target="_blank">Hook &amp; Barrel Magazine &mdash; Best Hunting and Fishing Apps 2026 (PFG not listed)</a></div>
   </div>
 </div>
 
@@ -498,6 +500,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div id="d-fishbrain" class="details-panel">
         <p><strong>What they do:</strong> 20M+ logged catches, AI fish forecasts, smart fishing points, weather/tides/moon, 30+ state license info, top bait recommendations.</p>
         <p style="margin-top:8px;"><strong>Weakness:</strong> Heavy $10&ndash;13/month paywall is the most-cited negative in every 2026 review. Locks almost everything useful behind Pro. Its tackle marketplace has now been <strong>quietly shut down</strong> &mdash; a bolted-on commerce feature that didn&rsquo;t stick.</p>
+        <p style="margin-top:8px;"><strong>Update (July 9):</strong> Shipped a Garmin-powered HD depth-chart layer (0.5m accuracy) and a Parks &amp; Government Lands layer (public-land parcels and access boundaries) &mdash; both Pro-gated. A real utility upgrade to its mapping stack, and a reminder that public-access data is a gap on PFG&rsquo;s own roadmap.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free, local depth, real-time state data. Fishbrain users frustrated by paywall are natural PFG converts if PFG gains visibility.</p>
         <p style="margin-top:8px;"><a href="https://fishbrain.com/features" target="_blank">fishbrain.com &#x2197;</a></p>
       </div>
@@ -516,6 +519,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div id="d-fishangler" class="details-panel">
         <p><strong>What they do:</strong> Catch logbook, catch maps, social community, plus a proprietary FishForecast&trade; layer &mdash; weather radar, feeding windows, 14-day outlook, exact location precision.</p>
         <p style="margin-top:8px;"><strong>Update (July 2026):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Users are vocally unhappy &mdash; complaints center on losing features they&rsquo;d had for years. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
+        <p style="margin-top:8px;"><strong>Update (July 9):</strong> Third-party sentiment analysis (marlvel.ai) corroborates the backlash and adds detail &mdash; users describe the change as developers &ldquo;gaslighting&rdquo; them, and separate technical-trust complaints (fake profiles, upload loops) are compounding the paywall anger.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free forever, condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species. FishAngler&rsquo;s pivot is a live case study for PFG&rsquo;s free-core rubric (see Best Practices).</p>
         <p style="margin-top:8px;"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &#x2197;</a></p>
       </div>
@@ -1285,6 +1289,17 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 9, 2026</h3>
+    <ul>
+      <li><strong>Quiet cycle &mdash; no new competitors, clones, or PFG mentions found.</strong> All 13 tracked competitors and categories rechecked; PFG&rsquo;s third-party visibility (Reddit, X, forums, press, editorial roundups, app stores) is unchanged at zero.</li>
+      <li><strong>Fishbrain shipped two new Pro-gated map layers:</strong> Garmin-powered HD depth charts (0.5m accuracy) and a Parks &amp; Government Lands layer (public-land parcels, access boundaries). A genuine mapping-stack upgrade, and a signal that public-access data is a gap worth adding to PFG&rsquo;s own roadmap discussion.</li>
+      <li><strong>FishAngler VIP backlash deepened with corroborating third-party sentiment data</strong> (marlvel.ai): users describe the paywall pivot as developers &ldquo;gaslighting&rdquo; them, plus separate technical-trust complaints (fake profiles, upload loops) compounding the anger.</li>
+      <li><strong>onWater Fish&rsquo;s Arkansas data-depth verification (Opportunity #1 from v1.7) was not performed this window</strong> &mdash; carried forward as the top open action item rather than restated as a new finding. Flagging explicitly so it doesn&rsquo;t silently drop off after a second quiet scan.</li>
+      <li>Added two new monitoring sources to the Sources list (marlvel.ai app sentiment reports) for future scans to check directly rather than relying on general web search.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary

Routine competitive/market-landscape monitoring scan for PocketFishingGuide, per the recurring cadence documented in the dashboard's own Best Practices tab. Updates `competitive-dashboard.html` from v1.7 (July 8) to v1.8 (July 9).

This was a quiet cycle:

- **No new competitors, clones, or copycat apps identified.** All 13 tracked competitors and categories were rechecked; none show a new Arkansas move this window.
- **No new third-party PFG mentions.** Reddit, X/Twitter, fishing forums, press, editorial roundups (including a newly-checked Hook & Barrel 2026 list), and app-store listings all still return zero third-party results for "Pocket Fishing Guide." Visibility gap is unchanged.
- **Fishbrain shipped two new Pro-gated map layers:** a Garmin-powered HD depth-chart layer (0.5m accuracy) and a Parks & Government Lands layer (public-land parcels and access boundaries) — a real utility upgrade to its paywalled mapping stack, and a reminder that public-access data is a gap on PFG's own roadmap.
- **FishAngler's VIP paywall backlash is corroborated by a new third-party sentiment source** (marlvel.ai), adding detail: users describe the change as developers "gaslighting" them, plus separate technical-trust complaints (fake profiles, upload loops) compounding the anger.
- **onWater Fish's Arkansas data-depth verification — flagged as Opportunity #1 in the July 8 scan — was not performed this window.** Carried forward explicitly as the top open action item so it doesn't silently drop after a second quiet scan, rather than being restated as a "new" finding.

Also noted (separate from competitive intel): PFG's own landing-page copy surfaced in search includes claims (funding raised, an app-store category ranking) that read as placeholder/aspirational marketing text rather than verified facts — flagged in the Intelligence Report tab as worth an internal check, not acted on here.

Updated: header version/date, summary-bar signal, Intelligence Report tab (all four sections), Top Recommendations #1 copy, Fishbrain and FishAngler competitor cards, Sources list (5 new links), and a new v1.8 entry in the append-only History tab.

## Test plan

- [x] Verified `<div>` open/close tag counts balance (458/458) via a Node script
- [ ] Open `competitive-dashboard.html` in a browser and click through all 8 tabs, confirm the Fishbrain/FishAngler card updates and new History entry render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1bgqzxvX3NRcggqHJRqw4


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1bgqzxvX3NRcggqHJRqw4)_