### PR TITLE
[Chore] PFG competitive intelligence dashboard — July 13 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 13, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> The AI fish-ID/measurement niche keeps crowding &mdash; three more entrants (AnglerAI, AnglersAI, AINGLER) found this scan, none Arkansas-aware. <strong>onWater Fish</strong> remains PFG&rsquo;s sharpest positioning collision, unchanged this window. Still zero third-party mentions of PFG anywhere, confirmed again via direct Reddit/X/forum search &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -343,32 +343,32 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 13 Scan</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>Three more AI fish-ID/measurement apps found and added to the AI-native watch-list group:</strong> AnglerAI (Google Play; AI species ID from photo + fishing forecast, tide times, solunar calendar; explicitly markets that it never sells location data), AnglersAI (App Store, dev: Wright Media LLC; AR-based fish length/weight measuring tool, free up to 10 measurements then $9.99/mo), and AINGLER (aingler.ai; AI-judged fishing tournament platform &mdash; auto-enters catches into eligible tournaments, free to use, $6.50/tournament entry fee). None are Arkansas- or condition-aware; AINGLER is a different niche (competitive judging) rather than an intelligence guide.</li>
+        <li><strong>Naming collision risk flagged:</strong> AnglerAI and AnglersAI are two unrelated apps with near-identical names and overlapping AI-fish-ID pitches &mdash; a sign this sub-category is getting crowded and easily confused, worth remembering when PFG eventually chooses app-store keywords/branding.</li>
+        <li><strong>onWater Fish, FishGuide AI, FishTips:</strong> no material change this window &mdash; all three confirmed still active with the same positioning logged in the July 8 scan. onWater&rsquo;s Arkansas data-depth verification (Opportunity #1) is still outstanding.</li>
+        <li><strong>FishAngler&rsquo;s VIP paywall</strong> &mdash; more detail surfaced: the backlash traces to a v5.0.0 update that specifically pulled &ldquo;bite times&rdquo; behind VIP; a third-party sentiment report (marlvel.ai) now explicitly flags this as &ldquo;high churn risk.&rdquo; FishAngler partly walked it back by adding a free 7-day forecast plus marine data (SST, currents) to the free tier.</li>
+        <li><strong>Fishbrain</strong> now markets its BiteTime feature as &ldquo;powered by advanced AI&rdquo; (App Store, May 2026) &mdash; an AI-branding move even though its tackle marketplace remains shut down.</li>
+        <li><strong>onX Fish</strong> footprint unchanged &mdash; still 11 states via Missouri/Montana, no Arkansas move detected.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
+        <li><strong>Public footprint unchanged, still first-party only.</strong> pocketfishinguide.com/waters is live and Google-indexed, surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>A direct search for &ldquo;Pocket Fishing Guide&rdquo; across Reddit, X/Twitter, and forums returned zero results this scan</strong> &mdash; not just no relevant hits, no hits at all. Confirms the visibility gap is still total, not partial.</li>
+        <li><strong>No PFG listing on Google Play or the App Store,</strong> confirmed again this scan (Opportunity #3, unaddressed). One naming note for whenever that listing ships: &ldquo;Pocket Fishing&rdquo; (com.pagenetsoft.fishing_deluxe) is an unrelated virtual-fishing <em>game</em> already on Google Play &mdash; a near-identical name that could cause app-store search confusion if PFG&rsquo;s listing doesn&rsquo;t lead with &ldquo;Guide&rdquo; and &ldquo;Arkansas&rdquo; in its title/keywords.</li>
         <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>FishTips and onWater Fish</strong> both continue to outrank PFG for Arkansas-specific fishing-app queries &mdash; unchanged since the last scan.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
+        <li><strong>The AI-native cluster keeps widening, not deepening:</strong> with AnglerAI, AnglersAI, and AINGLER added, the AI-native watch-list group now spans six apps (FishGPT, Fish AI, Fishial.AI, AnglerAI, AnglersAI, AINGLER). All remain generic/national with no Arkansas or condition-aware data &mdash; reinforces that PFG&rsquo;s planned Claude API assistant should stay narrowly AR-specific rather than compete as a generalist.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including any new add this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification- and AI-chat-first direction.</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
         <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
@@ -376,10 +376,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
+        <li><strong>Paywalls remain the top complaint, and the case study got sharper:</strong> a third-party sentiment report now explicitly labels FishAngler&rsquo;s VIP rollout &ldquo;high churn risk.&rdquo; Combined with Fishbrain&rsquo;s long-standing $10&ndash;13/mo paywall backlash, PFG&rsquo;s free-forever model is a genuine, evidence-backed differentiator.</li>
+        <li><strong>Market size and participation figures unchanged</strong> since the July 8 scan: $217.27M fishing-app market (2026) growing to $587.14M by 2035 at 11.68% CAGR; 57.9M US anglers in 2024 (record high, 19% participation) against a 23% one-year churn rate. Still a strong signal for retention-focused UX.</li>
         <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
+        <li><strong>Local depth wins &mdash; but the field is still crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground (Opportunity #1, still outstanding).</li>
         <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
       </ul>
     </div>
@@ -459,6 +459,11 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=app.abacusai.anglerai.twa" target="_blank">AnglerAI &mdash; Google Play (AI fish ID + forecast)</a></div>
+    <div class="source-item"><a href="https://apps.apple.com/us/app/anglersai/id6747051635" target="_blank">AnglersAI &mdash; App Store (AR fish measuring, $9.99/mo)</a></div>
+    <div class="source-item"><a href="https://www.aingler.ai/" target="_blank">AINGLER &mdash; AI-Judged Fishing Tournament Platform</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel.ai &mdash; FishAngler Sentiment &amp; Intel Report 2026 (&ldquo;high churn risk&rdquo;)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.pagenetsoft.fishing_deluxe" target="_blank">&ldquo;Pocket Fishing&rdquo; &mdash; unrelated Google Play game (naming collision risk)</a></div>
   </div>
 </div>
 
@@ -516,6 +521,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div id="d-fishangler" class="details-panel">
         <p><strong>What they do:</strong> Catch logbook, catch maps, social community, plus a proprietary FishForecast&trade; layer &mdash; weather radar, feeding windows, 14-day outlook, exact location precision.</p>
         <p style="margin-top:8px;"><strong>Update (July 2026):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Users are vocally unhappy &mdash; complaints center on losing features they&rsquo;d had for years. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
+        <p style="margin-top:8px;"><strong>Update (July 13 scan):</strong> The v5.0.0 update specifically pulled &ldquo;bite times&rdquo; behind VIP; a third-party sentiment report (marlvel.ai) now explicitly calls this &ldquo;high churn risk.&rdquo; FishAngler partly walked it back by adding a free 7-day forecast plus marine data (SST, currents) to the free tier &mdash; but the core paywall and backlash remain.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free forever, condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species. FishAngler&rsquo;s pivot is a live case study for PFG&rsquo;s free-core rubric (see Best Practices).</p>
         <p style="margin-top:8px;"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &#x2197;</a></p>
       </div>
@@ -682,19 +688,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
     <div class="card">
       <div class="card-header" onclick="toggleDetails('d-ainative')" style="cursor:pointer;">
-        <div><div class="card-title">AI-Native Fishing Apps</div><div class="card-sub">FishGPT &middot; Fish AI &middot; Fishial.AI &middot; New Category</div></div>
+        <div><div class="card-title">AI-Native Fishing Apps</div><div class="card-sub">FishGPT &middot; Fish AI &middot; Fishial.AI &middot; AnglerAI &middot; AnglersAI &middot; AINGLER</div></div>
         <span class="badge badge-muted">Low Threat</span>
       </div>
       <div class="threat-meter">
-        <div class="threat-label"><span>Threat to PFG</span><span>Low (watch-list)</span></div>
-        <div class="threat-bar"><div class="threat-fill threat-low" style="width:15%"></div></div>
+        <div class="threat-label"><span>Threat to PFG</span><span>Low (watch-list, growing roster)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:18%"></div></div>
       </div>
-      <div class="tags"><span class="tag">Chatbot Q&amp;A</span><span class="tag">Photo Fish ID</span><span class="tag">Generic</span><span class="tag">No Local Data</span></div>
+      <div class="tags"><span class="tag">Chatbot Q&amp;A</span><span class="tag">Photo Fish ID</span><span class="tag">AR Measuring</span><span class="tag">Tournament Judging</span><span class="tag">Generic</span><span class="tag">No Local Data</span></div>
       <div id="d-ainative" class="details-panel">
-        <p><strong>What they do:</strong> A new wave of single-purpose AI apps &mdash; FishGPT (chat assistant), Fish AI (location + species chat), and standalone Fishial.AI (photo identification, also licensed by GilledIt). All launched or gained traction in 2026.</p>
-        <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions rather than scoring real water data. Worth a quarterly recheck in case one adds state-level intelligence.</p>
-        <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware and Arkansas-specific to avoid competing head-on with these generalists.</p>
-        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a></p>
+        <p><strong>What they do:</strong> A growing wave of single-purpose AI apps, now six tracked as a group: FishGPT (chat assistant), Fish AI (location + species chat), standalone Fishial.AI (photo identification, also licensed by GilledIt), <strong>AnglerAI</strong> (Google Play; AI fish ID + forecast + tide/solunar, privacy-forward), <strong>AnglersAI</strong> (App Store; AR-based fish length/weight measuring, $9.99/mo after 10 free), and <strong>AINGLER</strong> (aingler.ai; AI-judged fishing tournament platform, auto-enters catches into eligible tournaments, $6.50/tournament fee).</p>
+        <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions or judge/measure catches rather than scoring real water data. AnglerAI and AnglersAI have confusingly similar names/pitches &mdash; a sign of a crowding, not-yet-differentiated sub-category. Worth a quarterly recheck in case one adds state-level intelligence.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot or measuring tool for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware and Arkansas-specific to avoid competing head-on with these generalists.</p>
+        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a> &middot; <a href="https://www.aingler.ai/" target="_blank">aingler.ai &#x2197;</a></p>
       </div>
     </div>
 
@@ -1285,6 +1291,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 13, 2026</h3>
+    <ul>
+      <li><strong>Three more AI fish-ID/measurement apps found:</strong> AnglerAI (Google Play; AI photo species ID + forecast + tide/solunar), AnglersAI (App Store, dev: Wright Media LLC; AR fish measuring, $9.99/mo after 10 free), and AINGLER (aingler.ai; AI-judged tournament platform, $6.50/tournament entry fee). Folded into the existing AI-Native Fishing Apps watch-list card, which now spans six apps. None are Arkansas- or condition-aware.</li>
+      <li><strong>Naming collision flagged:</strong> AnglerAI and AnglersAI are unrelated apps with near-identical names/pitches &mdash; the AI-fish-ID sub-category is crowding fast. Separately, an unrelated Google Play game called &ldquo;Pocket Fishing&rdquo; was found &mdash; worth remembering for ASO keyword choice whenever PFG&rsquo;s own store listing ships (Opportunity #3).</li>
+      <li><strong>FishAngler VIP backlash sharpened:</strong> a third-party sentiment report (marlvel.ai) now explicitly labels the v5.0.0 paywall rollout &ldquo;high churn risk,&rdquo; strengthening the free-core rubric case study. FishAngler has partially walked it back with a free 7-day forecast plus SST/currents data.</li>
+      <li><strong>Fishbrain</strong> now markets its BiteTime feature as &ldquo;powered by advanced AI&rdquo; (May 2026) &mdash; a branding move, not a new capability; its tackle marketplace remains shut down.</li>
+      <li><strong>No change</strong> to onWater Fish, FishGuide AI, FishTips, or onX Fish positioning this window &mdash; all confirmed active with the same status logged July 8. Opportunity #1 (verify onWater&rsquo;s actual Arkansas data depth) remains outstanding and is still the top-priority action.</li>
+      <li><strong>PFG mentions:</strong> zero third-party results confirmed again via direct Reddit/X/forum search &mdash; not just no relevant hits, no hits at all. No App Store/Google Play listing yet. Market size and participation figures unchanged from the July 8 scan.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
- Routine competitive/market-landscape scan for Pocket Fishing Guide, appended as v1.8 to `competitive-dashboard.html`.
- Three new AI fish-ID/measurement apps found and added to the AI-native watch-list group: **AnglerAI**, **AnglersAI**, **AINGLER** (AI-judged tournament platform) — none Arkansas- or condition-aware.
- Flagged a naming-collision risk: AnglerAI/AnglersAI have near-identical names, and an unrelated Google Play game called "Pocket Fishing" exists — a note for PFG's future App Store/Play Store keyword choices.
- Sharpened the FishAngler VIP paywall case study with a third-party report explicitly calling it "high churn risk," plus their partial walk-back (free 7-day forecast, SST/currents added).
- Noted Fishbrain now brands its BiteTime feature as "powered by advanced AI" (branding only, no new capability).
- Reconfirmed **zero third-party PFG mentions** across Reddit/X/forums/editorial roundups, and no PFG App Store/Google Play listing yet — the visibility gap remains the binding constraint, not the product.
- Market size and angler-participation figures unchanged from the July 8 (v1.7) scan.

## Test plan
- [x] Verified `<div>` open/close tag balance in the modified HTML.
- [x] Confirmed all new content renders within existing tab structure (Intelligence Report, Competitor Landscape, History) without new markup patterns.
- [ ] Human: open the dashboard in a browser and spot-check the new AI-Native card and v1.8 history entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbSeeatptWdNaWuiPGbPq2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbSeeatptWdNaWuiPGbPq2)_