### PR TITLE
[Chore] Update PFG competitive intelligence dashboard — July 15 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 15, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> Quiet scan &mdash; no new competitors, clones, or PFG mentions surfaced this window. The one open item moved slightly: onWater Fish&rsquo;s public Arkansas marketing copy leans on broad, non-AR-specific species (Striped Bass, Bluegill, Spotted Bass) rather than PFG&rsquo;s spawn-phase/AGFC-cited species set &mdash; a partial signal its AR depth may be shallower than the &ldquo;AI-native&rdquo; framing implies, but this is from marketing pages, not a hands-on app check, so Opportunity #1 stays open. FishAngler&rsquo;s VIP paywall backlash is intensifying, not fading &mdash; a sharper live case study for PFG&rsquo;s free-core rubric.
   </div>
 </div>
 
@@ -343,44 +343,44 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 15, 2026</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>No new competitors, clones, or copycats identified this scan.</strong> All 13 tracked competitors were rechecked; no additions to the tracking list this window.</li>
+        <li><strong>onWater Fish:</strong> no product update found since the last scan. Its Arkansas marketing pages (now found at both <code>/state/arkansas</code> and <code>/us/arkansas</code>) highlight Striped Bass, Bluegill, and Spotted Bass as popular AR species &mdash; a broader, more generic species set than PFG&rsquo;s spawn-phase-tracked list (White Bass, Crappie). This is a partial signal from marketing copy only, not a hands-on app check &mdash; Opportunity #1 (verify AR data depth directly) remains open and is still the top-priority action.</li>
+        <li><strong>FishAngler VIP backlash has sharpened, not faded.</strong> Third-party sentiment tracking now specifically ties the paywall to a &ldquo;v5.0.0&rdquo; release that gated bite times, plus UI complaints (chopped labels, missing tide info) &mdash; sentiment services now flag &ldquo;high churn risk&rdquo; and warn of users defecting to Fishbrain or Fishing Points. A sharper live case study for PFG&rsquo;s free-core positioning than last scan captured.</li>
+        <li><strong>Fish AI&rsquo;s positioning came into clearer focus:</strong> it markets itself on &ldquo;scientific behavioral modeling&rdquo; and a conversational &ldquo;AI Fish Coach&rdquo; rather than crowdsourced data &mdash; a refinement of, not a change to, its Low-threat watch-list status.</li>
+        <li><strong>GilledIt&rsquo;s Fishial.AI photo ID</strong> is still unshipped, still tracking for Q3 2026. <strong>onX Fish</strong> has made no further move toward Arkansas or Missouri since the last scan &mdash; Montana (its home state) remains its latest expansion.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Public footprint unchanged, still first-party only.</strong> pocketfishinguide.com and pocketfishinguide.com/waters remain live and Google-indexed, surfacing for Arkansas fishing-app queries. This is the product&rsquo;s own site, not third-party coverage.</li>
+        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings again returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began.</li>
+        <li><strong>One search result surfaced an unverifiable claim</strong> of a &ldquo;premium subscription&rdquo; on the PFG site (14-day forecasts, ad-free tier). A follow-up search found no corroboration anywhere else, and this dashboard could not fetch the live site directly this scan to confirm or deny it &mdash; flagged for a manual human spot-check rather than treated as fact; likely an AI-search summarization artifact conflating PFG with a competitor&rsquo;s paid tier.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup. One new roundup was found this scan &mdash; <strong>Hook &amp; Barrel Magazine&rsquo;s &ldquo;Best Hunting and Fishing Apps, Cameras and Tech Tools for 2026&rdquo;</strong> &mdash; added to the editorial pitch target list.</li>
+        <li><strong>AGFC Mobile</strong> still dominates Arkansas fishing-app search results; no AGFC news this window relates to any digital fishing-intelligence partnership (its recent announcements are the Legacy Lunker bass-genetics program and an outdoor-safety partnership with Arkansas&rsquo;s electric cooperatives &mdash; unrelated to apps).</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
-        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
+        <li><strong>Gamification remains the industry-wide default</strong> (GilledIt challenges/badges, Fishbuddy XP, MyFishing Book tournament tiers) &mdash; no change this window.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator.</li>
+        <li><strong>AI assistant positioning:</strong> Fish AI&rsquo;s new &ldquo;AI Fish Coach&rdquo; framing (conversational, advice-giving) is close in spirit to PFG&rsquo;s planned Claude API assistant. Reinforces that PFG&rsquo;s version needs to stay condition-aware and AGFC-cited to read as more than &ldquo;another AI fishing chatbot.&rdquo;</li>
+        <li><strong>Community catch logging:</strong> unchanged &mdash; GilledIt, Fishbrain, FishAngler have robust social logs; PFG has this as a &ldquo;Later&rdquo; backend item.</li>
+        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still stops at Missouri; no movement this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Paywalls remain the top complaint, and FishAngler is now the sharpest live example.</strong> Its VIP rollout (v5.0.0, gating bite times and the solunar calendar) is drawing &ldquo;high churn risk&rdquo; warnings from third-party sentiment trackers. PFG&rsquo;s free model is a genuine, increasingly differentiated advantage.</li>
+        <li><strong>No new market-size or participation data found this scan</strong> &mdash; the RBFF/ASA figures from the last scan (57.9M anglers, 23% one-year churn) stand unchanged; no newer report was located.</li>
+        <li><strong>Beginners still underserved:</strong> no competitor shipped structured education this window. PFG&rsquo;s roadmap still addresses the largest untapped segment.</li>
+        <li><strong>Local depth wins &mdash; the open question is whether it&rsquo;s still uncontested.</strong> onWater Fish and FishTips both claim Arkansas presence; this scan found a partial (not conclusive) signal that onWater&rsquo;s AR content may be shallower than its &ldquo;AI-native&rdquo; branding implies, based on species framing in its marketing pages. A direct in-app check is still needed before treating this as resolved.</li>
+        <li><strong>AGFC partnership:</strong> still a live, zero-cost opportunity &mdash; no news this window changes that.</li>
       </ul>
     </div>
   </div>
@@ -389,8 +389,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; still not done, still first</div>
+      <div class="opp-desc">Unresolved for a second scan running. This window&rsquo;s search-based check found a partial signal &mdash; onWater&rsquo;s Arkansas marketing pages foreground broad, non-AR-specific species (Striped Bass, Bluegill, Spotted Bass) rather than PFG&rsquo;s spawn-phase-tracked species set, hinting its AR data may be shallower than the &ldquo;AI-native&rdquo; branding implies. But this is marketing copy, not the product itself. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG &mdash; AGFC integration, spawn-phase science, condition-aware scoring. This is the one recommendation on this list that requires a human, not another search pass.</div>
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
     </div>
   </div>
@@ -459,6 +459,11 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://www.hookandbarrel.com/gear/hunting-and-fishing-apps-2026" target="_blank">Hook &amp; Barrel Magazine &mdash; Best Hunting and Fishing Apps 2026 (new editorial target)</a></div>
+    <div class="source-item"><a href="https://www.onwaterapp.com/us/arkansas" target="_blank">onWater Fish &mdash; /us/arkansas (alt URL, species framing checked this scan)</a></div>
+    <div class="source-item"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler Blog &mdash; VIP tier (v5.0.0 backlash detail, July 15 recheck)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel.ai &mdash; FishAngler Sentiment &amp; Intel Report 2026</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/com-fishai-app" target="_blank">Marlvel.ai &mdash; Fish AI Sentiment &amp; Intel Report 2026</a></div>
   </div>
 </div>
 
@@ -515,7 +520,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="tags"><span class="tag">VIP Paywall</span><span class="tag">Social</span><span class="tag">2.5M Users</span><span class="tag">Declining Sentiment</span></div>
       <div id="d-fishangler" class="details-panel">
         <p><strong>What they do:</strong> Catch logbook, catch maps, social community, plus a proprietary FishForecast&trade; layer &mdash; weather radar, feeding windows, 14-day outlook, exact location precision.</p>
-        <p style="margin-top:8px;"><strong>Update (July 2026):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Users are vocally unhappy &mdash; complaints center on losing features they&rsquo;d had for years. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
+        <p style="margin-top:8px;"><strong>Update (July 15, 2026):</strong> Launched &ldquo;FishAngler VIP&rdquo; (v5.0.0), moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Third-party sentiment trackers now flag &ldquo;high churn risk&rdquo; and cite specific complaints &mdash; chopped-off labels, missing tide info, bite times gated &mdash; with users reportedly threatening to defect to Fishbrain or Fishing Points. No longer meaningfully &ldquo;free&rdquo; for its core value, and the backlash is intensifying, not settling.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free forever, condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species. FishAngler&rsquo;s pivot is a live case study for PFG&rsquo;s free-core rubric (see Best Practices).</p>
         <p style="margin-top:8px;"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &#x2197;</a></p>
       </div>
@@ -1033,7 +1038,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">1</div>
     <div class="opp-content">
       <div class="opp-title">Verify onWater Fish&rsquo;s Actual Arkansas Depth</div>
-      <div class="opp-desc">onWater Fish now markets &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; and already has live Arkansas pages. Before reacting further, do a direct hands-on comparison: open onWater on an Arkansas water and check for AGFC-cited data, spawn-phase tracking, and condition-aware scoring versus PFG. This single check determines whether the rest of this list should accelerate.</div>
+      <div class="opp-desc">Still open after a second scan. The July 15 search-based check found onWater&rsquo;s Arkansas marketing copy leans on broad species (Striped Bass, Bluegill, Spotted Bass) rather than PFG&rsquo;s spawn-phase-tracked list &mdash; a partial signal of shallower AR depth, but not a substitute for using the actual product. Do a direct hands-on comparison: open onWater on an Arkansas water and check for AGFC-cited data, spawn-phase tracking, and condition-aware scoring versus PFG. This single check determines whether the rest of this list should accelerate.</div>
       <div class="opp-meta">
         <span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span><span class="badge badge-muted">0 Cost</span>
         <a href="https://www.onwaterapp.com/state/arkansas" target="_blank" class="badge badge-blue" style="text-decoration:none;">onWater AR &#x2197;</a>
@@ -1195,7 +1200,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <li><strong>Credibility:</strong> Built on GitHub Pages, open-source, powered by USGS/NWS public APIs.</li>
           <li><strong>CTA:</strong> Link to live app + 2&ndash;3 screenshots showing lure recommendations in action.</li>
         </ul>
-        <p style="margin-top:8px;">Target outlets: <a href="https://fishingbooker.com/blog/best-fishing-apps/" target="_blank">FishingBooker</a> &middot; <a href="https://www.wired2fish.com" target="_blank">Wired2Fish</a> &middot; <a href="https://kayakanglermag.com" target="_blank">Kayak Angler</a> &middot; <a href="https://guidesly.com" target="_blank">Guidesly</a></p>
+        <p style="margin-top:8px;">Target outlets: <a href="https://fishingbooker.com/blog/best-fishing-apps/" target="_blank">FishingBooker</a> &middot; <a href="https://www.wired2fish.com" target="_blank">Wired2Fish</a> &middot; <a href="https://kayakanglermag.com" target="_blank">Kayak Angler</a> &middot; <a href="https://guidesly.com" target="_blank">Guidesly</a> &middot; <a href="https://www.hookandbarrel.com/gear/hunting-and-fishing-apps-2026" target="_blank">Hook &amp; Barrel Magazine</a></p>
       </div>
     </div>
 
@@ -1285,6 +1290,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 15, 2026</h3>
+    <ul>
+      <li><strong>Quiet scan &mdash; no new competitors, clones, or PFG mentions found.</strong> All 13 tracked competitors rechecked; count unchanged. Third-party searches across Reddit, X/Twitter, forums, press, and app stores again returned zero results for &ldquo;Pocket Fishing Guide.&rdquo;</li>
+      <li><strong>Opportunity #1 (verify onWater Fish&rsquo;s Arkansas depth) is still unresolved after a second scan,</strong> but got a partial signal: onWater&rsquo;s AR marketing pages (found at both <code>/state/arkansas</code> and <code>/us/arkansas</code>) foreground broad species (Striped Bass, Bluegill, Spotted Bass) rather than PFG&rsquo;s spawn-phase-tracked list, hinting at possibly shallower AR depth than its &ldquo;AI-native&rdquo; branding implies. This is from marketing copy, not the app itself &mdash; a hands-on check remains the top-priority open action and cannot be closed by further search passes.</li>
+      <li><strong>FishAngler&rsquo;s VIP paywall backlash sharpened with more specific detail:</strong> tied to a v5.0.0 release gating bite times, with third-party sentiment trackers now warning of &ldquo;high churn risk&rdquo; and users threatening to defect to Fishbrain or Fishing Points. Strengthens the free-core case study in Best Practices.</li>
+      <li><strong>Fish AI&rsquo;s positioning clarified:</strong> markets itself on &ldquo;scientific behavioral modeling&rdquo; and a conversational &ldquo;AI Fish Coach&rdquo; rather than crowdsourced data &mdash; a refinement, not a threat-level change.</li>
+      <li><strong>One new editorial roundup identified:</strong> Hook &amp; Barrel Magazine&rsquo;s &ldquo;Best Hunting and Fishing Apps, Cameras and Tech Tools for 2026&rdquo; &mdash; added to the editorial pitch target list (Opportunity #2 / Best Practices).</li>
+      <li><strong>Direct fetches of pocketfishinguide.com and onwaterapp.com were blocked by this session&rsquo;s network egress policy</strong> (403, not a site-side error) &mdash; this scan relied on search-engine summaries rather than live page content for those two sites. One search summary surfaced an unverified, uncorroborated claim of a &ldquo;premium subscription&rdquo; on the PFG site; a follow-up search found no support for it anywhere else, so it is flagged here as noise pending a manual human check rather than folded into the dashboard as fact.</li>
+      <li>No market-size, participation, or churn data newer than the July 8 RBFF/ASA figures was found this scan; those numbers stand unchanged. onX Fish and GilledIt&rsquo;s Fishial.AI are both unchanged since the last scan.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
- Routine competitive-intelligence scan of `competitive-dashboard.html` (v1.7 → v1.8): no new competitors, clones, or PFG mentions found this window — all 13 tracked competitors rechecked, count unchanged.
- Opportunity #1 (verify onWater Fish's Arkansas data depth) remains open after a second scan; found a partial, search-only signal (onWater's AR marketing pages foreground broad species rather than PFG's spawn-phase-tracked list) but this still requires a hands-on app check, not another search pass.
- FishAngler's VIP paywall backlash sharpened with more specific detail (v5.0.0, "high churn risk" per third-party sentiment trackers) — strengthens the free-core case study in Best Practices.
- Added one new editorial roundup target (Hook & Barrel Magazine) to the pitch list.
- Noted that direct fetches of pocketfishinguide.com and onwaterapp.com were blocked by this session's network policy (403) — this scan relied on search-engine summaries for those two sites, and one uncorroborated "premium subscription" claim surfaced in a search summary is flagged as unverified noise rather than treated as fact.
- New History tab entry (v1.8 · July 15, 2026) logs all of the above for the running competitive timeline.

## Test plan
- [x] Verified HTML tag balance (`<div>`/`</div>` counts match) after edits
- [ ] Visual check in browser: History tab shows v1.8 entry, summary-bar signal text reads correctly, no broken links in updated Sources section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7q4JhYiVHNSRoJso2kT7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7q4JhYiVHNSRoJso2kT7u)_