### PR TITLE
[Feature] Competitive dashboard v1.8 — July 17 scan update

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 17, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> Stable window &mdash; no new competitors, clones, or PFG mentions surfaced this scan. <strong>onWater Fish&rsquo;s Arkansas data depth is still unverified for the third scan running</strong> and remains the single open action item carried forward since July 8. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -339,6 +339,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="warn-box">
     <strong>PFG not found in any major 2026 fishing app roundup.</strong> This is a visibility gap &mdash; not a product gap. The app is not indexed in editorial lists (FishingBooker, GilledIt, Fishbox, Guidesly, Wired2Fish). App store presence and editorial outreach are needed to enter these rankings.
+  </div>
+
+  <div class="info-box">
+    <strong>July 17 scan: stable window.</strong> No new competitors, clones, or PFG mentions surfaced since the July 8 scan below &mdash; the findings on this tab remain the latest substantive intelligence. See the History tab (v1.8) for this scan&rsquo;s confirm-and-hold entry.
   </div>
 
   <div class="grid-2" style="margin-bottom:20px;">
@@ -1285,6 +1289,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 17, 2026</h3>
+    <ul>
+      <li><strong>Stable window &mdash; no new competitors, clones, or copycats found.</strong> The tracked list of 13 competitors is unchanged since July 8; targeted searches for new Arkansas-specific or hyperlocal-conditions entrants surfaced only the same national incumbents already on file.</li>
+      <li><strong>PFG mentions unchanged:</strong> still zero third-party hits across Reddit, X/Twitter, fishing forums, press, and app-store listings. Public footprint remains first-party only (pocketfishinguide.com, Google-indexed).</li>
+      <li><strong>onWater Fish&rsquo;s Arkansas data depth is still unverified &mdash; now the third consecutive scan without resolution.</strong> This remains the single highest-priority open item; a direct hands-on comparison (Opportunity #0) has not yet been completed.</li>
+      <li>No movement from onX Fish (still Montana as its latest expansion, no Arkansas signal), GilledIt (Fishial.AI still on track, unshipped, for Q3 2026), FishAngler (VIP paywall unchanged), or FishTips (same four AR water pages, no funding news).</li>
+      <li><strong>Beginner&rarr;expert education white space confirmed stable across three consecutive scans</strong> (June 23 &rarr; July 7 &rarr; July 8 &rarr; July 17) &mdash; no competitor has claimed it. This remains PFG&rsquo;s cleanest differentiator.</li>
+      <li>No new market-size report superseded prior figures; one unverified secondary data point noted for color only (industry commentary citing ~62% growth in fishing-app downloads, ~38% adoption lift from AI fish-recognition features) &mdash; not confirmed against a primary source.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
- Routine competitive-intelligence scan for PocketFishingGuide (July 17, 2026), delta vs. the July 8 (v1.7) baseline.
- **Stable window:** no new competitors, clones, or PocketFishingGuide mentions surfaced. All previously tracked competitors (onWater Fish, onX Fish, GilledIt, FishAngler, FishTips, Fish AI, FishGuide AI) show no material movement since July 8.
- **Open item carried forward:** onWater Fish's Arkansas data depth remains unverified for a third consecutive scan and stays the top-priority action item.
- Adds a `v1.8 · July 17, 2026` entry to the append-only History tab, refreshes the header date/version badge, and updates the top-of-report signal banner and summary alert to reflect the confirm-and-hold result.

## Test plan
- [x] Verified `<div>`/`</div>` tag balance in `competitive-dashboard.html` after edits (454/454)
- [ ] Open the dashboard in a browser and click through the Intelligence Report and History tabs to confirm the new v1.8 entry renders correctly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01XZZDeLR2fXZYNwYxox5f9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZZDeLR2fXZYNwYxox5f9K)_