### PR TITLE
Update PFG competitive intelligence dashboard — July 20 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 20, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">14</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> First hands-on evidence on <strong>onWater Fish</strong>&rsquo;s Arkansas depth: independent 2026 app reviews report its topographic/depth-contour layer is live only for Minnesota, Michigan, and Florida &mdash; not yet Arkansas &mdash; suggesting its AR pages may sit on the same general-coverage tier as the rest of its map, not a dedicated build-out. Still unconfirmed on AGFC citation and spawn-phase data specifically. Separately, PFG&rsquo;s own live water catalog is confirmed at <strong>57 Arkansas waters</strong>, up from the 39 this dashboard has cited &mdash; a correction to PFG&rsquo;s own numbers, not a competitor move. Still zero third-party mentions of PFG anywhere.
   </div>
 </div>
 
@@ -343,44 +343,42 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 20 Scan</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
-        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
+        <li><strong>First real signal on onWater Fish&rsquo;s Arkansas data depth.</strong> Independent 2026 app reviews (Sports Illustrated, Outside Bozeman) report onWater&rsquo;s topographic depth-contour layer is currently live only for Minnesota, Michigan, and Florida, with &ldquo;more states coming soon.&rdquo; That implies Arkansas is likely still on the general-coverage tier, not a dedicated build-out &mdash; a meaningful data point, though it does not confirm or deny AGFC-citation or spawn-phase depth specifically. Recommend keeping the direct hands-on check, now narrower in scope.</li>
+        <li><strong>New watch-list add: BUBBA SCORETRACKER LIVE.</strong> BUBBA and Major League Fishing officially launched real-time tournament scoring for consumers on July 13, 2026 &mdash; live leaderboard tracking for organizers, anglers, and fans. Tournament-specific, same segment as BassForecast; not an Arkansas-intelligence competitor, but another signal that big fishing-adjacent brands are investing in live digital tooling.</li>
+        <li><strong>Fish AI is growing fast:</strong> now rated 4.7/5 across 18.7K App Store reviews and shipped an &ldquo;AI Fish Coach&rdquo; for personalized tips and spot suggestions, on top of the global leaderboards added July 5. The AI-native cluster (onWater, FishGuide AI, Fish AI) keeps compounding user traction even though none are Arkansas-specific.</li>
+        <li><strong>No change this window:</strong> onX Fish&rsquo;s footprint remains Missouri/Montana with no further move toward Arkansas; GilledIt&rsquo;s Fishial.AI photo ID stays on track for Q3 2026, unshipped; FishAngler&rsquo;s VIP paywall is unchanged and still drawing backlash (see Mentions below).</li>
+        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified. 14 competitors now tracked, up from 13.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com/waters remains live and Google-indexed, and search snippets now accurately describe live water temp, spawn phase, and USGS gauge data across Arkansas waters &mdash; still the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings again returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup checked this scan (Kayak Angler, FishingBooker, GilledIt, Fishbox, Guidesly, Wired2Fish, Hook &amp; Barrel).</li>
+        <li><strong>Internal correction, not a competitive move:</strong> PFG&rsquo;s live data catalog (<code>data/waters.json</code>) now covers <strong>57 Arkansas water bodies</strong>, not the 39 this dashboard has cited since v1.4. Updated everywhere below.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
-        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
+        <li><strong>Gamification keeps accelerating industry-wide:</strong> Fish AI&rsquo;s leaderboards and new AI Fish Coach, GilledIt&rsquo;s challenges/badges/XP, and BUBBA SCORETRACKER LIVE&rsquo;s real-time tournament leaderboards (new this window) all reinforce a competition-framed direction, not an educational one.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor identified this scan, including BUBBA or the AI-native cluster, has shipped a true educational skill-progression arc. This remains PFG&rsquo;s cleanest differentiator.</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI remain live AI-forward products with growing ratings. PFG&rsquo;s planned Claude API assistant still needs to stay condition-aware and AGFC-cited to differentiate from a generic AI fishing chatbot.</li>
+        <li><strong>PFG&rsquo;s own roadmap is moving too:</strong> the codebase shows a Pocket Score engine and AGFC-corroborated Weekly Report feature already built (foundation shipped dark, June 28) &mdash; ahead of where this dashboard&rsquo;s Opportunities list assumed. Worth reflecting once the feature is user-facing.</li>
         <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Paywalls remain the top complaint.</strong> Independent 2026 sentiment tracking now explicitly frames FishAngler as &ldquo;self-sabotaging&rdquo; through its VIP paywall and UI redesign, with FishAngler itself publicly acknowledging user frustration (May 12, 2026) without reversing course. PFG&rsquo;s free model is a genuine, reinforced differentiator.</li>
+        <li><strong>Record participation, record churn</strong> (unchanged from last scan): 57.9M Americans fished in 2024 (record high, 19% participation), 23% one-year churn, female youth quitting at an 11-point higher rate after 18. Still a strong, data-backed case for PFG&rsquo;s retention/onboarding roadmap.</li>
+        <li><strong>Beginners underserved:</strong> Fishbox remains the only competitor explicitly targeting new anglers; no one has shipped structured education. Unchanged.</li>
+        <li><strong>Local depth wins &mdash; and PFG&rsquo;s actual footprint is bigger than this dashboard has been saying.</strong> PFG&rsquo;s real catalog is 57 Arkansas waters with real-time USGS/NWS data and condition-aware scoring &mdash; no competitor matches that combination. onWater Fish&rsquo;s Arkansas depth now looks more likely to be shallow (see above) than previously feared.</li>
+        <li><strong>AGFC partnership:</strong> No fishing-intelligence partnership news this window; AGFC did sign a new 3-year outdoor-safety partnership with the Electric Cooperatives of Arkansas (unrelated segment), which at least confirms AGFC actively pursues external partnerships &mdash; a mild positive signal for outreach.</li>
       </ul>
     </div>
   </div>
@@ -389,8 +387,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-title">Finish the onWater Fish depth check &mdash; scope narrowed, not closed</div>
+      <div class="opp-desc">This scan found the first outside evidence: independent 2026 reviews report onWater&rsquo;s depth-contour map layer is live only in Minnesota, Michigan, and Florida, suggesting Arkansas likely isn&rsquo;t getting a dedicated data build-out. That lowers the odds onWater matches PFG on data depth, but it doesn&rsquo;t confirm AGFC-citation or spawn-phase tracking either way. Spend 20&ndash;30 minutes in the actual app on an Arkansas water to close the gap definitively.</div>
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
     </div>
   </div>
@@ -455,10 +453,15 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://www.businesswire.com/news/home/20250602251753/en/onWater-Fish-App-Launches-Next-Gen-Tools-to-Power-the-Future-of-Angling" target="_blank">BusinessWire &mdash; onWater AI Trout Measuring Tool (beta)</a></div>
     <div class="source-item"><a href="https://www.onwaterapp.com/features/angler-intelligence" target="_blank">onWater Fish &mdash; Angler Intelligence feature page</a></div>
     <div class="source-item"><a href="https://apps.apple.com/us/app/fishing-app-fishguide-ai/id6747693672" target="_blank">FishGuide AI &mdash; App Store (v2.0, Ice Fishing Mode, Bite Times)</a></div>
-    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.fishai.app" target="_blank">Fish AI &mdash; Google Play (leaderboards added July 5, 2026)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.fishai.app" target="_blank">Fish AI &mdash; Google Play (AI Fish Coach, 4.7/5 across 18.7K reviews)</a></div>
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://www.si.com/onsi/fishing/gear-reviews/onwater-fishing-app-review-smart-tech-plan-trips-track-results-catch-fish" target="_blank">Sports Illustrated &mdash; onWater App Review (depth data: MN/MI/FL only)</a></div>
+    <div class="source-item"><a href="https://outsidebozeman.com/gear/product-reviews/misc/review-onwater-app" target="_blank">Outside Bozeman &mdash; onWater App Review</a></div>
+    <div class="source-item"><a href="https://www.stocktitan.net/news/AOUT/bubba-mlf-officially-launch-scoretracker-live-for-consumers-while-ejkevxbv8vi1.html" target="_blank">StockTitan &mdash; BUBBA &amp; MLF Launch SCORETRACKER LIVE (July 13, 2026)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel &mdash; FishAngler 2026 Sentiment &amp; Intel Report</a></div>
+    <div class="source-item"><a href="https://www.kark.com/life/arkansas-outdoors/arkansas-game-and-fish-commission-and-electric-cooperatives-of-arkansas-team-up-to-promote-outdoor-recreation-safety/" target="_blank">KARK &mdash; AGFC &amp; Electric Cooperatives Partnership (3-year, outdoor safety)</a></div>
   </div>
 </div>
 
@@ -515,7 +518,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="tags"><span class="tag">VIP Paywall</span><span class="tag">Social</span><span class="tag">2.5M Users</span><span class="tag">Declining Sentiment</span></div>
       <div id="d-fishangler" class="details-panel">
         <p><strong>What they do:</strong> Catch logbook, catch maps, social community, plus a proprietary FishForecast&trade; layer &mdash; weather radar, feeding windows, 14-day outlook, exact location precision.</p>
-        <p style="margin-top:8px;"><strong>Update (July 2026):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Users are vocally unhappy &mdash; complaints center on losing features they&rsquo;d had for years. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
+        <p style="margin-top:8px;"><strong>Update (July 20 scan):</strong> Launched &ldquo;FishAngler VIP,&rdquo; moving FishForecast, the solunar calendar, and exact location data behind a paywall, alongside a UI redesign. Third-party sentiment tracking now explicitly calls the move &ldquo;self-sabotaging,&rdquo; and FishAngler itself publicly acknowledged user frustration (May 12, 2026) without reversing the paywall. No longer meaningfully &ldquo;free&rdquo; for its core value.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free forever, condition-aware lure scoring, USGS real-time data, spawn phase tracking for AR species. FishAngler&rsquo;s pivot is a live case study for PFG&rsquo;s free-core rubric (see Best Practices).</p>
         <p style="margin-top:8px;"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler VIP &#x2197;</a></p>
       </div>
@@ -550,7 +553,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="tags"><span class="tag">20K+ Reports</span><span class="tag">Commerce</span><span class="tag">Navionics Charts</span><span class="tag">Free/Pro</span></div>
       <div id="d-omnia" class="details-panel">
         <p><strong>What they do:</strong> 20,000+ fishing reports by lake/species/season. PRO adds Navionics depth charts, water temp, clarity, real-time wind. Unique &ldquo;shop by lake&rdquo; tackle commerce model.</p>
-        <p style="margin-top:8px;"><strong>Threat:</strong> Covers AR broadly but with shallow crowd-sourced reports vs. PFG&rsquo;s real-time condition scoring.</p>
+        <p style="margin-top:8px;"><strong>Threat:</strong> Covers AR broadly but with shallow crowd-sourced reports vs. PFG&rsquo;s real-time condition scoring across 57 Arkansas waters.</p>
         <p style="margin-top:8px;"><strong>Opportunity:</strong> Omnia&rsquo;s affiliate commerce model is the reference for PFG&rsquo;s planned lure-link monetization. Consider Omnia as an affiliate partner.</p>
         <p style="margin-top:8px;"><a href="https://www.omniafishing.com" target="_blank">omniafishing.com &#x2197;</a></p>
       </div>
@@ -637,10 +640,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
       <div class="tags"><span class="tag">AI-Native</span><span class="tag">AI Trout Measuring</span><span class="tag">AR Lakes/Rivers</span><span class="tag">Species Maps</span></div>
       <div id="d-onwater" class="details-panel">
-        <p><strong>What they do:</strong> Browse rivers/lakes across Arkansas, boat ramps, species habitat maps &mdash; plus, new as of this scan, &ldquo;Angler Intelligence&trade;&rdquo; (launched Oct 24, 2025), marketed as &ldquo;the First AI-Native Fishing Experience.&rdquo; Includes a patented AI Trout Measuring Tool (beta) that IDs fish from a photo across 107 species and returns length/weight with no reference object needed, built on live gauge/weather/access data.</p>
-        <p style="margin-top:8px;"><strong>Escalation (July 2026):</strong> This was missed in earlier scans and is now the closest positioning match found to date &mdash; &ldquo;AI-native&rdquo; is near-identical language to how PFG describes itself, and onWater is already live in Arkansas, not a future risk. Unverified: whether its Arkansas data has AGFC-level depth or is the same shallow national-database coverage seen elsewhere. Needs a direct hands-on check.</p>
+        <p><strong>What they do:</strong> Browse rivers/lakes across Arkansas, boat ramps, species habitat maps &mdash; plus &ldquo;Angler Intelligence&trade;&rdquo; (launched Oct 24, 2025), marketed as &ldquo;the First AI-Native Fishing Experience.&rdquo; Includes a patented AI Trout Measuring Tool (beta) that IDs fish from a photo across 107 species and returns length/weight with no reference object needed, built on live gauge/weather/access data.</p>
+        <p style="margin-top:8px;"><strong>Update (July 20 scan):</strong> Independent 2026 app reviews (Sports Illustrated, Outside Bozeman) report onWater&rsquo;s topographic depth-contour map layer is live only for Minnesota, Michigan, and Florida &ldquo;with more states coming soon&rdquo; &mdash; Arkansas is not yet in that set. That suggests AR is more likely on the general-coverage tier than a dedicated build-out, which would ease this threat somewhat. Still unconfirmed either way on AGFC-citation and spawn-phase depth specifically &mdash; a direct hands-on check remains the fastest way to close this out.</p>
         <p style="margin-top:8px;"><strong>PFG edge (if depth checks out as shallow):</strong> Condition-aware lure scoring, spawn phase tracking, AGFC-cited reports &mdash; a specific intelligence layer vs. onWater&rsquo;s general-purpose AI Q&amp;A and photo ID.</p>
-        <p style="margin-top:8px;"><a href="https://www.onwaterapp.com/state/arkansas" target="_blank">onwaterapp.com/arkansas &#x2197;</a> &middot; <a href="https://www.onwaterapp.com/features/angler-intelligence" target="_blank">Angler Intelligence &#x2197;</a></p>
+        <p style="margin-top:8px;"><a href="https://www.onwaterapp.com/us/arkansas" target="_blank">onwaterapp.com/arkansas &#x2197;</a> &middot; <a href="https://www.onwaterapp.com/features/angler-intelligence" target="_blank">Angler Intelligence &#x2197;</a></p>
       </div>
     </div>
 
@@ -692,9 +695,28 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="tags"><span class="tag">Chatbot Q&amp;A</span><span class="tag">Photo Fish ID</span><span class="tag">Generic</span><span class="tag">No Local Data</span></div>
       <div id="d-ainative" class="details-panel">
         <p><strong>What they do:</strong> A new wave of single-purpose AI apps &mdash; FishGPT (chat assistant), Fish AI (location + species chat), and standalone Fishial.AI (photo identification, also licensed by GilledIt). All launched or gained traction in 2026.</p>
+        <p style="margin-top:8px;"><strong>Update (July 20 scan):</strong> Fish AI is compounding traction fastest of the three &mdash; now rated 4.7/5 across 18.7K App Store reviews and shipped an &ldquo;AI Fish Coach&rdquo; for personalized tips and spot suggestions, on top of the global leaderboards added July 5.</p>
         <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions rather than scoring real water data. Worth a quarterly recheck in case one adds state-level intelligence.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware and Arkansas-specific to avoid competing head-on with these generalists.</p>
-        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a></p>
+        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a> &middot; <a href="https://play.google.com/store/apps/details?id=com.fishai.app" target="_blank">Fish AI &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-bubba')" style="cursor:pointer;">
+        <div><div class="card-title">BUBBA SCORETRACKER LIVE</div><div class="card-sub">MLF Tournament Scoring &middot; New This Scan</div></div>
+        <span class="badge badge-muted">Low Threat</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>Low (different segment)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:15%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Live Scoring</span><span class="tag">Tournament</span><span class="tag">MLF Brand</span><span class="tag">Consumer Launch</span></div>
+      <div id="d-bubba" class="details-panel">
+        <p><strong>What they do:</strong> BUBBA and Major League Fishing officially launched SCORETRACKER LIVE for consumers on July 13, 2026, bringing MLF&rsquo;s real-time tournament scoring technology to organizers, anglers, and fans.</p>
+        <p style="margin-top:8px;"><strong>Threat:</strong> Tournament/competition segment, same lane as BassForecast &mdash; not an Arkansas-intelligence competitor. Notable mainly as another signal that established fishing brands are investing in live digital tooling.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Different use case entirely &mdash; PFG serves everyday condition/lure decisions, not competitive event scoring. No overlap expected.</p>
+        <p style="margin-top:8px;"><a href="https://www.stocktitan.net/news/AOUT/bubba-mlf-officially-launch-scoretracker-live-for-consumers-while-ejkevxbv8vi1.html" target="_blank">Launch announcement &#x2197;</a></p>
       </div>
     </div>
 
@@ -723,7 +745,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </thead>
       <tbody>
         <tr>
-          <td class="feature-name">Arkansas-specific depth (39+ waters)</td>
+          <td class="feature-name">Arkansas-specific depth (57 waters)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
@@ -924,7 +946,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <li><strong>FishTips</strong> &mdash; Arkansas-specific, guide-authored reports (Lake Erling, Lake Conway, Arkansas River, Spring River) behind a subscription. No AI, no real-time USGS/NWS/AGFC data.</li>
       <li><strong>AGFC Mobile</strong> &mdash; Official state app for licensing only. No fishing intelligence. Highest-value partner target.</li>
       <li><strong>Fishbrain / FishAngler</strong> &mdash; Cover AR in national databases. No local depth, no USGS integration, no spawn phase data for AR species.</li>
-      <li><strong>Omnia Fishing</strong> &mdash; Crowd-sourced reports for some AR lakes. Shallow vs. PFG&rsquo;s 39-body real-time database.</li>
+      <li><strong>Omnia Fishing</strong> &mdash; Crowd-sourced reports for some AR lakes. Shallow vs. PFG&rsquo;s 57-water real-time database.</li>
       <li><strong>No competitor yet combines real-time USGS/NWS data, condition-aware lure scoring, and AGFC-cited reports for Arkansas.</strong> This is PFG&rsquo;s structural moat &mdash; now contested on positioning, not yet on data depth.</li>
     </ul>
   </div>
@@ -946,7 +968,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="canvas-cell span1">
       <div class="canvas-label">Solution</div>
       <ul>
-        <li><strong>39-body AR water database</strong> with real-time USGS/NWS feeds</li>
+        <li><strong>57-water AR database</strong> with real-time USGS/NWS feeds</li>
         <li>Condition-aware lure scoring (clarity &times; flow &times; phase)</li>
         <li>Spawn phase tracking for White Bass, Crappie + more</li>
         <li>Zero paywall, zero backend &mdash; GitHub Pages</li>
@@ -1191,7 +1213,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <p>Structure for pitching PFG to fishing app roundup editors:</p>
         <ul style="padding-left:16px; margin-top:8px;">
           <li><strong>Hook:</strong> &ldquo;The only free fishing app with real-time USGS water conditions for Arkansas &mdash; tells you exactly what lure to throw based on today&rsquo;s water clarity and flow.&rdquo;</li>
-          <li><strong>Differentiator:</strong> 39 Arkansas water bodies, condition-aware lure scoring, spawn phase tracking. Zero paywall.</li>
+          <li><strong>Differentiator:</strong> 57 Arkansas water bodies, condition-aware lure scoring, spawn phase tracking. Zero paywall.</li>
           <li><strong>Credibility:</strong> Built on GitHub Pages, open-source, powered by USGS/NWS public APIs.</li>
           <li><strong>CTA:</strong> Link to live app + 2&ndash;3 screenshots showing lure recommendations in action.</li>
         </ul>
@@ -1285,6 +1307,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 20, 2026</h3>
+    <ul>
+      <li><strong>Internal correction:</strong> PFG&rsquo;s own live data catalog (<code>data/waters.json</code>) covers 57 Arkansas water bodies, not the 39 this dashboard had cited since v1.4. Updated across the Feature Matrix, Lean Canvas, Market Data, and Intelligence Report tabs &mdash; not a competitor move, a fix to PFG&rsquo;s own numbers.</li>
+      <li><strong>Progress on the top-priority action item from v1.7:</strong> independent 2026 reviews (Sports Illustrated, Outside Bozeman) report onWater Fish&rsquo;s topographic depth-contour layer is currently live only for Minnesota, Michigan, and Florida &mdash; not Arkansas &mdash; suggesting its AR pages likely sit on the general-coverage tier rather than a dedicated build-out. This narrows, but does not close, the open question on AGFC-citation and spawn-phase depth; a direct hands-on check remains open as Opportunity #1.</li>
+      <li><strong>New competitor added:</strong> BUBBA SCORETRACKER LIVE, a real-time tournament scoring app from BUBBA and Major League Fishing, launched for consumers July 13, 2026. Tournament segment, same lane as BassForecast &mdash; low direct threat, but a signal of continued fishing-brand investment in live digital tooling. 14 competitors now tracked, up from 13.</li>
+      <li><strong>FishAngler VIP backlash reinforced by third-party sentiment tracking,</strong> which now explicitly frames the move as &ldquo;self-sabotaging&rdquo;; FishAngler itself publicly acknowledged user frustration (May 12, 2026) without reversing the paywall.</li>
+      <li><strong>Fish AI</strong> is compounding traction within the AI-native cluster &mdash; now 4.7/5 across 18.7K reviews with a new &ldquo;AI Fish Coach&rdquo; feature, on top of the July 5 leaderboards.</li>
+      <li><strong>PFG mentions unchanged:</strong> zero third-party mentions found across Reddit, X, forums, press, or app stores; zero editorial roundup inclusions. Public first-party footprint (pocketfishinguide.com/waters) remains Google-indexed and accurately described in search snippets.</li>
+      <li>No new Arkansas-specific competitors, PFG clones, or copycats identified this scan. onX Fish and GilledIt&rsquo;s Fishial.AI both unchanged from the last scan.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
- Routine competitive-monitoring scan of `competitive-dashboard.html` (v1.7 → v1.8), following the established append-only History-tab cadence.
- **Verified and corrected PFG's own water catalog**: `data/waters.json` in `pocket-fishing-guide` confirms 57 Arkansas waters, not the 39 this dashboard has cited since v1.4. Fixed across the summary alert, Feature Matrix, Lean Canvas, Market Data, and Intelligence Report.
- **First outside evidence on last scan's #1 action item** (verify onWater Fish's Arkansas data depth): independent 2026 reviews (Sports Illustrated, Outside Bozeman) report onWater's topographic depth-contour layer is currently live only for Minnesota, Michigan, and Florida — Arkansas isn't in that set yet, narrowing (not closing) the open question on AGFC-citation/spawn-phase depth.
- Added a new competitor: **BUBBA SCORETRACKER LIVE** (MLF real-time tournament scoring, launched for consumers July 13, 2026) — low threat, tournament segment, but a market signal. 14 competitors now tracked, up from 13.
- Reinforced the FishAngler VIP paywall backlash with third-party sentiment tracking (now explicitly called "self-sabotaging") and FishAngler's own public acknowledgment of user frustration.
- Noted Fish AI's growing traction (4.7/5 across 18.7K reviews, new "AI Fish Coach" feature).
- No new PFG clones, editorial mentions, or third-party mentions of Pocket Fishing Guide found this scan.

## Test plan
- [x] `python3 -c "from html.parser import HTMLParser; ..."` — HTML parses without errors
- [x] `<div>`/`</div>` and `<li>`/`</li>` tag counts balanced (469/469 and 121/121)
- [x] Manual review of all diff hunks for accuracy against sourced research
- [ ] Visual smoke-test in a browser (not run — Playwright not available in this session; content-only edits to an already-valid HTML/CSS/JS structure)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Xmug8aLjWH91VW35rveawf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xmug8aLjWH91VW35rveawf)_