### PR TITLE
[Feature] Competitive dashboard v1.8 — July 21, 2026 scan update

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 21, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">14</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> <strong>onWater Fish&rsquo;s Arkansas depth is now OSINT-confirmed, not just marketing copy</strong> &mdash; its public Arkansas pages show live streamflow/water-temp tracking, a 100+ species map layer, and auto-logged journal entries (flow, weather, moon phase), resolving last scan&rsquo;s top action item. It remains PFG&rsquo;s sharpest positioning collision. A new AI-native entrant, <strong>BassForce</strong> (bass-only, pro-angler-built lure AI, $4.99/mo premium), is now tracked at 14 competitors. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -343,32 +343,31 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 21 Scan</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
-        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
+        <li><strong>onWater Fish&rsquo;s Arkansas depth is now OSINT-confirmed &mdash; this was last scan&rsquo;s top action item.</strong> Its public onwaterapp.com/state/arkansas and /water/arkansas-river pages show live streamflow and water-temperature tracking (&ldquo;My Waters&rdquo;), a species-map layer covering 100+ fish, and a Journal that auto-logs river flow, weather, time of day, and moon phase per catch &mdash; real condition-aware infrastructure, not a shallow landing page wearing AI-native language. AGFC-level regulatory integration and spawn-phase science specifically remain unconfirmed, but the core threat assessment (High) is validated, not downgraded.</li>
+        <li><strong>New AI-native entrant added to tracking: BassForce.</strong> iOS-only, bass-specific lure-recommendation app built with ~200 years of combined input from professional bass anglers, condition-tuned (water clarity, cover, wind) AI lure picks, 10-day weather, named &ldquo;Best Fishing App&rdquo; by Major League Fishing. Free with a $4.99/mo premium tier (top-5 picks per pro, pro-consensus &ldquo;Premium Match&rdquo;). Species- and use-case-narrow (bass only, no Arkansas-specific water data), but its pro-credibility angle on AI recommendations is a model worth studying. 14 competitors now tracked, up from 13.</li>
+        <li><strong>FishAngler VIP backlash is sustained, not fading.</strong> Third-party trackers (marlvel.ai) now describe FishAngler as &ldquo;aggressively shifting toward a VIP-centric model,&rdquo; with fresh complaints specifically about bite-time data removal and forecast reliability. Reinforces last scan&rsquo;s free-core case study rather than adding new information.</li>
+        <li><strong>onX Fish and GilledIt unchanged this window.</strong> onX Fish&rsquo;s footprint still stops at Montana (May 2026) with no further movement toward Arkansas. GilledIt&rsquo;s Fishial.AI photo ID remains targeted for Q3 2026, still unshipped (Fishial.AI&rsquo;s own docs now cite 640+ identifiable species at 95%+ accuracy on common species).</li>
+        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified. FishTips&rsquo;s Arkansas pages (Lake Erling, Lake Conway, Arkansas River, Spring River) are unchanged since last scan.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
+        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com/waters is live and indexed, describing free Arkansas fishing intelligence across dozens of tracked waters (live water temperature, spawn phase, USGS data, 14-day forecasts). This is the product&rsquo;s own site surfacing in search, not third-party coverage.</li>
+        <li><strong>A direct Reddit/forum search for &ldquo;Pocket Fishing Guide&rdquo; returned zero relevant results this window</strong> (top hits were an unrelated Terraria game item) &mdash; consistent with every prior scan. Public footprint has begun; organic buzz has not.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup (FishingBooker, GilledIt, Kayak Angler, Fishbox, Hook &amp; Barrel) reviewed this window.</li>
         <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>FishTips and onWater Fish</strong> both continue to out-rank PFG for Arkansas-specific fishing-app queries &mdash; visibility gap unchanged, not narrowing.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
+        <li><strong>Pro-credibility as an AI-trust signal:</strong> BassForce leans on named professional anglers backing its AI lure picks rather than an anonymous model &mdash; a positioning idea PFG could borrow by citing AGFC data and named AR guides alongside its own condition-aware scoring, to build trust for the planned Claude API assistant.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including BassForce, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification- and AI-picks-first direction.</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, Fish AI, and now BassForce are all live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
         <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
@@ -376,10 +375,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
+        <li><strong>Paywalls remain the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s VIP tier are the most-cited negatives across 2026 reviews; BassForce&rsquo;s freemium split ($4.99/mo for full pro picks) is a lighter version of the same tension. PFG&rsquo;s fully free model is a genuine differentiator against all three.</li>
+        <li><strong>Record participation, record churn</strong> (RBFF/Outdoor Foundation, unchanged this window): 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate. This remains a strong signal for retention-focused UX, already on PFG&rsquo;s roadmap under User Retention &amp; Personalization.</li>
+        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor, including this window&rsquo;s new adds, has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
+        <li><strong>Local depth wins &mdash; and onWater&rsquo;s is now confirmed real.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does, but onWater Fish&rsquo;s Arkansas-specific streamflow/water-temp/species layers mean the gap is genuinely narrowing, not just a marketing claim. Direct AGFC-integration and spawn-phase comparison is still the sharpest remaining unknown.</li>
         <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
       </ul>
     </div>
@@ -389,8 +388,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-title">Confirm AGFC-level and spawn-phase depth against onWater &mdash; the remaining unknown</div>
+      <div class="opp-desc">This scan&rsquo;s OSINT pass confirmed onWater Fish has real Arkansas-specific infrastructure (live streamflow/water-temp tracking, a 100+ species map, auto-logged condition journals) &mdash; it is not a shallow marketing page. What remains unverified is whether it matches PFG on AGFC-cited regulatory data and spawn-phase science specifically. Do a direct side-by-side on one Arkansas water (e.g. Beaver Lake or the White River) and document the gap or its absence. This is now a confirmation task, not a discovery task &mdash; the structural threat itself is no longer in question.</div>
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
     </div>
   </div>
@@ -459,6 +458,12 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://www.onwaterapp.com/water/arkansas-river" target="_blank">onWater Fish &mdash; Arkansas River (streamflow, water temp, access)</a></div>
+    <div class="source-item"><a href="https://www.onwaterapp.com/blog/new-fish-species-layer-means-you-can-fish-smarter" target="_blank">onWater Fish &mdash; Species Map Layer (100+ species)</a></div>
+    <div class="source-item"><a href="https://docs.fishial.ai/" target="_blank">Fishial.AI &mdash; Docs (640+ species, 95%+ accuracy)</a></div>
+    <div class="source-item"><a href="https://bassforcefishing.com/" target="_blank">BassForce &mdash; Pro Bass Fishing Guide App</a></div>
+    <div class="source-item"><a href="https://majorleaguefishing.com/industry-news/new-bassforce-app-reads-interprets-fishings-greatest-minds/" target="_blank">Major League Fishing &mdash; New BassForce App</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel &mdash; FishAngler Sentiment &amp; Intel Report (2026)</a></div>
   </div>
 </div>
 
@@ -698,6 +703,24 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
     </div>
 
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-bassforce')" style="cursor:pointer;">
+        <div><div class="card-title">BassForce</div><div class="card-sub">Pro-Angler AI Lure Picks &middot; Bass-Only &middot; New</div></div>
+        <span class="badge badge-muted">Low Threat</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>Low (species-narrow, no AR data)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:20%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Bass Only</span><span class="tag">Pro-Curated AI</span><span class="tag">Freemium $4.99/mo</span><span class="tag">iOS Only</span></div>
+      <div id="d-bassforce" class="details-panel">
+        <p><strong>What they do:</strong> iOS lure-recommendation app built with input from professional bass anglers (~200 years combined experience). AI suggests lure choices tuned to location, weather, water clarity, and cover; 10-day forecast. Named &ldquo;Best Fishing App&rdquo; by Major League Fishing. Free core with a $4.99/mo premium tier (top-5 picks per pro, pro-consensus &ldquo;Premium Match&rdquo;).</p>
+        <p style="margin-top:8px;"><strong>Overlap:</strong> Its condition-tuned lure AI is conceptually close to PFG&rsquo;s condition-aware scoring, but scoped to bass only, no Arkansas water data, no USGS/NWS integration, no multi-species coverage.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Multi-species, Arkansas-specific, real-time USGS/NWS, fully free. Its pro-credibility framing (named anglers backing the AI) is a positioning idea worth studying for PFG&rsquo;s own planned assistant.</p>
+        <p style="margin-top:8px;"><a href="https://bassforcefishing.com/" target="_blank">bassforcefishing.com &#x2197;</a></p>
+      </div>
+    </div>
+
   </div>
 </div>
 
@@ -719,6 +742,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <th>BassForecast</th>
           <th>Fishbox</th>
           <th>AGFC</th>
+          <th>BassForce</th>
         </tr>
       </thead>
       <tbody>
@@ -727,105 +751,105 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Real-time USGS / NWS data</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Condition-aware lure scoring</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Spawn phase tracking</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Free core (no paywall)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
         </tr>
         <tr>
           <td class="feature-name">Zero backend / GitHub Pages</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Community / social catch log</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">AI fishing assistant</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
         </tr>
         <tr>
           <td class="feature-name">Education / skill progression</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Gamification (badges / challenges)</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Paddler / kayak mode</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">PWA / mobile install</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Bathymetric maps</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Hardware (sonar/GPS) integration</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Weekly digest / fishing reports</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
       </tbody>
     </table>
@@ -1285,6 +1309,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 21, 2026</h3>
+    <ul>
+      <li><strong>onWater Fish&rsquo;s Arkansas depth confirmed via OSINT &mdash; last scan&rsquo;s top action item is resolved.</strong> Its public Arkansas pages (state and Arkansas River) show live streamflow/water-temperature tracking (&ldquo;My Waters&rdquo;), a 100+ species map layer, and a Journal that auto-logs river flow, weather, and moon phase per catch. This is genuine condition-aware infrastructure, not a shallow page borrowing PFG&rsquo;s language. Threat rating holds at High; the remaining open question is narrower &mdash; whether it matches PFG on AGFC-cited regulatory data and spawn-phase science specifically (new Opportunity #0, replacing the &ldquo;hands-on review&rdquo; ask).</li>
+      <li><strong>New competitor added: BassForce</strong> &mdash; iOS-only, bass-specific AI lure-recommendation app built with input from professional bass anglers, named &ldquo;Best Fishing App&rdquo; by Major League Fishing. Free core with a $4.99/mo premium tier. Species-narrow and Arkansas-blind, but its pro-credibility framing for AI recommendations is a positioning idea worth borrowing for PFG&rsquo;s planned assistant. 14 competitors now tracked, up from 13. Feature Matrix gained a BassForce column.</li>
+      <li><strong>FishAngler VIP backlash confirmed sustained, not fading:</strong> third-party tracker Marlvel now characterizes the shift as &ldquo;aggressive,&rdquo; citing fresh complaints on bite-time data removal and forecast reliability &mdash; reinforces rather than changes last scan&rsquo;s free-core case study.</li>
+      <li><strong>onX Fish and GilledIt unchanged:</strong> onX Fish still stops at Montana (no further move toward Arkansas); GilledIt&rsquo;s Fishial.AI photo ID remains targeted for Q3 2026, unshipped.</li>
+      <li><strong>PFG mentions unchanged:</strong> first-party site (pocketfishinguide.com/waters) remains the only public footprint; a direct Reddit/forum search for &ldquo;Pocket Fishing Guide&rdquo; returned zero relevant results. Visibility gap persists as the binding constraint, not the product.</li>
+      <li>No GitHub clones, App Store copycats, or new Arkansas-specific entrants beyond BassForce were identified this window.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary

Routine competitive-monitoring pass for `competitive-dashboard.html` (PFG Market Intelligence Dashboard), per the recurring cadence documented in the History tab.

- **onWater Fish's Arkansas depth is now OSINT-confirmed** — resolves the prior scan's top action item. Public pages show live streamflow/water-temp tracking, a 100+ species map, and auto-logged condition journals for Arkansas waters. Threat rating holds at High; the remaining open question narrows to AGFC-level regulatory and spawn-phase parity specifically (updated Opportunity #0).
- **New competitor added: BassForce** — an iOS bass-only AI lure-recommendation app built with professional-angler input, freemium at $4.99/mo. 14 competitors now tracked (up from 13). Added a full row of Feature Matrix entries and a Competitor Landscape card.
- **FishAngler VIP backlash confirmed sustained** via a third-party sentiment tracker — reinforces, not changes, the existing free-core case study.
- **PFG mentions unchanged** — first-party site remains the only public footprint; still zero third-party mentions across forums/editorial.
- Appended a `v1.8 · July 21, 2026` entry to the append-only History tab, bumped the header/version badge, updated summary-bar stats and the Signal callout, and added new source links.

## Test plan

- [x] Verified balanced HTML tag counts (`div`, `table`, `tr`, `td`, `th`, `ul`, `li`) after edits
- [x] Confirmed the new Feature Matrix column (BassForce) has 11 cells in every row, matching the 11-column header
- [ ] Visual check in a browser recommended before merge (no build step / static HTML)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kg4fB4GDQsUnCY1X1Xaihe)_