### PR TITLE
Update PFG competitive intelligence dashboard — July 22 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,22 +302,22 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 22, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
-      <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
+      <span class="badge badge-muted">Pocket Fishing Guide &middot; web/ (Next.js + Supabase)</span>
       <span class="badge badge-blue">Arkansas Waters</span>
     </div>
   </div>
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">16</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> The competitive set just widened in a direction PFG hadn&rsquo;t tracked: <strong>Captain Experiences and Guidesly already have live, active Arkansas guide-booking supply</strong> (28 AR trips / 15+ guides on Captain Experiences; multiple AR lake/river listings on Guidesly) &mdash; directly relevant now that FishIn Buddy (PFG&rsquo;s planned guide-booking marketplace) is on the roadmap. onWater Fish&rsquo;s Arkansas-depth verification is still open (site blocked automated access this scan). Zero third-party mentions of PFG anywhere persists &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -343,44 +343,39 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 22 Update</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
-        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
+        <li><strong>Booking-marketplace competitor set added &mdash; overdue, and now live in Arkansas today.</strong> PFG&rsquo;s FishIn Buddy roadmap item (guide-booking marketplace) had zero tracked competitors until this scan. <strong>Captain Experiences</strong> already lists 28 Arkansas trips across 15+ guides (crappie, walleye, fly fishing, largemouth bass) with 5.0/5 across 7,581 verified reviews platform-wide. <strong>Guidesly</strong> already has multiple live Arkansas listings (Lake Ouachita striper, Beaver Lake crappie, Little Red River fly fishing). <strong>FishingBooker</strong> (already tracked as an editorial source) is also a direct marketplace competitor with 10&ndash;30% operator-set commission. All three are added as tracked competitors this scan &mdash; see Competitor Landscape.</li>
+        <li><strong>onWater Fish depth verification is still open &mdash; site blocked automated access this scan (HTTP 403).</strong> Escalation from the July 8 scan stands unresolved: still marketed as &ldquo;the First AI-Native Fishing Experience,&rdquo; still shows Arkansas pages, still unverified for AGFC-level data depth. This remains the top open action item (see Opportunity #1) and needs a manual, logged-in browser check rather than another automated pass.</li>
+        <li><strong>No material change this window</strong> for the rest of the tracked set: onX Fish&rsquo;s footprint is still 11 states with Missouri as the closest border to Arkansas (no new state added since May 2026); GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped; FishGuide AI and Fish AI show no further feature announcements since their early-July updates.</li>
+        <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified. Targeted searches for &ldquo;pocketfishinguide&rdquo; copycats/clones returned no relevant results.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
+        <li><strong>Public footprint unchanged since July 8.</strong> pocketfishinguide.com remains live and Google-indexed, surfacing in search snippets for water/species/condition detail &mdash; still the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings again returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
         <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Self-description correction:</strong> this dashboard&rsquo;s own Lean Canvas and Solution copy still described PFG as &ldquo;zero-backend GitHub Pages.&rdquo; Per the product&rsquo;s own CHANGELOG, the GitHub Pages root was retired July 6, 2026 in favor of the Next.js app under `web/` with a Supabase-backed Pocket Score engine and AGFC-corroborated Weekly Report &mdash; corrected in the Lean Canvas tab this scan so the dashboard doesn&rsquo;t misrepresent PFG&rsquo;s own architecture to anyone using it for positioning decisions.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
+        <li><strong>FishIn Buddy (guide-booking marketplace) roadmap item now has real, live incumbents to compete against for Arkansas guide supply</strong> &mdash; not a greenfield launch. Captain Experiences and Guidesly both already have established AR guide rosters and customer reviews. PFG&rsquo;s pricing plan (guide keeps 100% + 9% angler service fee, per FishIn Buddy scoping) undercuts Guidesly&rsquo;s 10% guide commission and FishingBooker&rsquo;s 10&ndash;30% operator-set commission on paper &mdash; but pricing alone won&rsquo;t move guides off platforms where they already have bookings and reviews. Supply-side (guide) acquisition, not angler demand, is likely the harder side of this two-sided market.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction (Fish AI leaderboards, GilledIt badges/XP, MyFishing Book tournament tiers).</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI remain live AI-forward products with no change this window. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Paywalls are still the top complaint</strong> across 2026 reviews (Fishbrain $10&ndash;13/mo, FishAngler VIP). PFG&rsquo;s free model remains a genuine differentiator, unchanged this window.</li>
+        <li><strong>Booking-side monetization has an established commission benchmark now:</strong> 10% (Guidesly) to 10&ndash;30% (FishingBooker, operator-set) is what guides currently pay to reach anglers online. PFG&rsquo;s 9%-angler-fee / 100%-guide-keep structure is a real, quotable differentiator for guide-acquisition outreach once FishIn Buddy is closer to launch.</li>
+        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both claim Arkansas presence; onWater&rsquo;s AGFC-level depth is still unverified pending the manual check in Opportunity #1.</li>
+        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips/Captain Experiences/Guidesly to replicate quickly.</li>
       </ul>
     </div>
   </div>
@@ -389,8 +384,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
+      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; still open, do this first</div>
+      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Automated access to onwaterapp.com/state/arkansas returned HTTP 403 this scan &mdash; this needs an actual human in a browser, not another routine pass. Spend 30 minutes in the app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move. Now two scans old (first flagged July 8).</div>
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
     </div>
   </div>
@@ -698,6 +693,58 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
     </div>
 
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-captainexp')" style="cursor:pointer;">
+        <div><div class="card-title">Captain Experiences</div><div class="card-sub">Guide Booking &middot; 28 AR Trips Live Today</div></div>
+        <span class="badge badge-red">Monitor &mdash; FishIn Buddy Overlap</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to FishIn Buddy (roadmap)</span><span>High</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-high" style="width:70%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Booking Marketplace</span><span class="tag">170K Users</span><span class="tag">3,000+ Guides</span><span class="tag">Commission-Based</span></div>
+      <div id="d-captainexp" class="details-panel">
+        <p><strong>What they do:</strong> Guide/charter booking marketplace, 170,000+ users, 3,000+ verified guides nationwide. Already lists 15 pages of Arkansas guides (28 trips) covering crappie, walleye, fly fishing, and largemouth bass, with platform-wide reviews averaging 5.0/5 across 7,581 ratings. Booking is free to the angler; commission taken from guides (exact % undisclosed in public terms).</p>
+        <p style="margin-top:8px;"><strong>Why it matters now:</strong> Newly added to tracking because PFG&rsquo;s FishIn Buddy roadmap item (guide-booking marketplace + crew planner) would compete directly with an incumbent that already has Arkansas guide supply and customer trust built up &mdash; not a hypothetical future competitor.</p>
+        <p style="margin-top:8px;"><strong>FishIn Buddy&rsquo;s edge on paper:</strong> proposed 100%-to-guide + 9% angler fee vs. Captain Experiences&rsquo; opaque commission cut. Needs guide-side outreach to actually convert, not just pricing.</p>
+        <p style="margin-top:8px;"><a href="https://captainexperiences.com/locations/arkansas" target="_blank">captainexperiences.com/arkansas &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-guidesly')" style="cursor:pointer;">
+        <div><div class="card-title">Guidesly</div><div class="card-sub">Guide Booking &middot; 10% Commission &middot; Live in AR</div></div>
+        <span class="badge badge-red">Monitor &mdash; FishIn Buddy Overlap</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to FishIn Buddy (roadmap)</span><span>High</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-high" style="width:70%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Booking Marketplace</span><span class="tag">10% Commission</span><span class="tag">$9.5M Raised</span><span class="tag">Guide Referral Program</span></div>
+      <div id="d-guidesly" class="details-panel">
+        <p><strong>What they do:</strong> Guide/charter booking marketplace, $9.5M raised (Jan 2025). Takes 10% commission on bookings from a guide&rsquo;s own site (guide keeps 90%); runs a guide-referral program ($100 credit per referred guide). Already has live Arkansas listings &mdash; Lake Ouachita striper, Beaver Lake crappie, Little Red River fly fishing among others &mdash; each with individually branded guide-service pages.</p>
+        <p style="margin-top:8px;"><strong>Why it matters now:</strong> Same FishIn Buddy overlap as Captain Experiences. Guidesly is also cited elsewhere in this dashboard as an editorial/discovery outlet (Opportunity #2) &mdash; it is simultaneously a potential distribution partner and a direct marketplace competitor once FishIn Buddy ships. Worth deciding which relationship to pursue before outreach starts.</p>
+        <p style="margin-top:8px;"><a href="https://guidesly.com/destination/us/arkansas" target="_blank">guidesly.com/arkansas &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-fishingbooker-mkt')" style="cursor:pointer;">
+        <div><div class="card-title">FishingBooker</div><div class="card-sub">Booking Marketplace &middot; 10&ndash;30% Commission</div></div>
+        <span class="badge badge-amber">Watch &mdash; FishIn Buddy Overlap</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to FishIn Buddy (roadmap)</span><span>Medium&ndash;High</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:60%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Booking Marketplace</span><span class="tag">10&ndash;30% Commission</span><span class="tag">Direct-Booking Add-on</span><span class="tag">Also an Editorial Outlet</span></div>
+      <div id="d-fishingbooker-mkt" class="details-panel">
+        <p><strong>What they do:</strong> The largest global fishing-charter booking marketplace. Operators set their own commission between 10&ndash;30% (5% increments); a separate &ldquo;FishingBooker Direct&rdquo; product charges 0% commission plus a 2.65% + $0.03 payment-processing fee for guides who want their own bookable site without the marketplace cut.</p>
+        <p style="margin-top:8px;"><strong>Dual role for PFG:</strong> FishingBooker is already tracked elsewhere in this dashboard purely as an editorial/discovery target (Opportunity #2 &mdash; get PFG into its app roundup). It is now also flagged here as a direct marketplace competitor for FishIn Buddy. Same relationship-management tension as Guidesly: valuable as a distribution partner today, a competitor once booking ships.</p>
+        <p style="margin-top:8px;"><a href="https://fishingbooker.com/direct" target="_blank">fishingbooker.com/direct &#x2197;</a></p>
+      </div>
+    </div>
+
   </div>
 </div>
 
@@ -758,7 +805,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
-          <td class="feature-name">Zero backend / GitHub Pages</td>
+          <td class="feature-name">Low-cost infra, no VC-scale backend</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
@@ -831,7 +878,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </table>
   </div>
   <div style="margin-top:16px; font-size:12px; color:var(--text-muted);">
-    PFG&rsquo;s structural moat: rows 1&ndash;6 (local depth, real-time data, condition scoring, spawn tracking, free core, zero-backend). No competitor matches these simultaneously for Arkansas. Roadmap rows 7&ndash;15 close the community and platform gaps. Hardware and bathymetric maps are intentionally out of scope.
+    PFG&rsquo;s structural moat: rows 1&ndash;6 (local depth, real-time data, condition scoring, spawn tracking, free core, low-cost infra). No competitor matches these simultaneously for Arkansas. Roadmap rows 7&ndash;15 close the community and platform gaps. Hardware and bathymetric maps are intentionally out of scope.
   </div>
 </div>
 
@@ -949,7 +996,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <li><strong>39-body AR water database</strong> with real-time USGS/NWS feeds</li>
         <li>Condition-aware lure scoring (clarity &times; flow &times; phase)</li>
         <li>Spawn phase tracking for White Bass, Crappie + more</li>
-        <li>Zero paywall, zero backend &mdash; GitHub Pages</li>
+        <li>Zero paywall, always free core &mdash; now on Next.js + Supabase (GitHub Pages root retired July 6, 2026)</li>
+        <li>AGFC-corroborated Pocket Score + Weekly Report (shipped June&ndash;July 2026)</li>
         <li>Education layer (planned): beginner &rarr; pro progression</li>
         <li>Paddler mode (in development)</li>
       </ul>
@@ -994,7 +1042,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="canvas-cell span2">
       <div class="canvas-label">Channels</div>
       <ul>
-        <li>GitHub Pages (current deployment)</li>
+        <li>Next.js app at www.pocketfishinguide.com (current deployment)</li>
         <li>AGFC community &amp; digital channels (partner target)</li>
         <li>AR fishing forums &amp; Facebook groups</li>
         <li>Editorial fishing app roundups &mdash; FishingBooker, Wired2Fish, Kayak Angler</li>
@@ -1005,11 +1053,10 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="canvas-cell span1">
       <div class="canvas-label">Cost Structure</div>
       <ul>
-        <li><strong>$0</strong> &mdash; GitHub Pages hosting</li>
         <li><strong>$0</strong> &mdash; USGS/NWS API (public)</li>
+        <li><strong>Low</strong> &mdash; Supabase (Pocket Score engine, fishing_reports store)</li>
         <li><strong>Low</strong> &mdash; Claude API for future AI features</li>
         <li><strong>Volunteer</strong> &mdash; Development time (TWT team)</li>
-        <li><strong>Future:</strong> Supabase backend when user base justifies it</li>
       </ul>
     </div>
     <div class="canvas-cell span2">
@@ -1019,7 +1066,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <li><strong>Near-term:</strong> Affiliate links on lure recommendations (Omnia/Tackle Warehouse/Amazon)</li>
         <li><strong>Growth:</strong> Local tackle shop sponsorships / directory listings</li>
         <li><strong>Future:</strong> Patreon tiers (free + premium + patron)</li>
-        <li><strong>Future:</strong> Guide profile + sponsor pages</li>
+        <li><strong>Future (FishIn Buddy):</strong> guide-booking fee &mdash; scoping doc proposes 100%-to-guide + 9% angler fee, undercutting Guidesly&rsquo;s 10% and FishingBooker&rsquo;s 10&ndash;30% commission benchmarks (see Competitor Landscape); commission-model conflict flagged internally still needs a decision</li>
       </ul>
     </div>
   </div>
@@ -1121,6 +1168,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
     </div>
   </div>
+
+  <div class="opp-card priority-high">
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">9</div>
+    <div class="opp-content">
+      <div class="opp-title">FishIn Buddy Needs a Guide-Acquisition Plan, Not Just a Pricing Edge</div>
+      <div class="opp-desc">Captain Experiences (28 AR trips, 15+ guides) and Guidesly (multiple live AR lake/river listings) are already established with Arkansas guides and their reviews. FishIn Buddy&rsquo;s proposed 100%-to-guide + 9%-angler-fee structure beats Guidesly&rsquo;s 10% and FishingBooker&rsquo;s 10&ndash;30% commission on paper, but undercutting price alone rarely moves guides who already have bookings and star ratings on an incumbent platform. Before FishIn Buddy&rsquo;s checkout ships, line up a short list of Arkansas guides not yet listed anywhere (or dual-listed and receptive to a 0%-fee pitch) as launch partners, and resolve the guide-commission model conflict flagged in the FishIn Buddy scoping doc (100%-keep bundle vs. 12&ndash;15% commission alternative) using these real benchmarks.</div>
+      <div class="opp-meta">
+        <span class="badge badge-red">High Priority</span><span class="badge badge-muted">Go-to-Market</span><span class="badge badge-muted">Roadmap Item</span>
+        <a href="https://captainexperiences.com/locations/arkansas" target="_blank" class="badge badge-blue" style="text-decoration:none;">Captain Experiences AR &#x2197;</a>
+        <a href="https://guidesly.com/destination/us/arkansas" target="_blank" class="badge badge-blue" style="text-decoration:none;">Guidesly AR &#x2197;</a>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- TAB 7: Best Practices -->
@@ -1192,7 +1252,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <ul style="padding-left:16px; margin-top:8px;">
           <li><strong>Hook:</strong> &ldquo;The only free fishing app with real-time USGS water conditions for Arkansas &mdash; tells you exactly what lure to throw based on today&rsquo;s water clarity and flow.&rdquo;</li>
           <li><strong>Differentiator:</strong> 39 Arkansas water bodies, condition-aware lure scoring, spawn phase tracking. Zero paywall.</li>
-          <li><strong>Credibility:</strong> Built on GitHub Pages, open-source, powered by USGS/NWS public APIs.</li>
+          <li><strong>Credibility:</strong> Open-source, powered by USGS/NWS public APIs, AGFC-corroborated Weekly Report.</li>
           <li><strong>CTA:</strong> Link to live app + 2&ndash;3 screenshots showing lure recommendations in action.</li>
         </ul>
         <p style="margin-top:8px;">Target outlets: <a href="https://fishingbooker.com/blog/best-fishing-apps/" target="_blank">FishingBooker</a> &middot; <a href="https://www.wired2fish.com" target="_blank">Wired2Fish</a> &middot; <a href="https://kayakanglermag.com" target="_blank">Kayak Angler</a> &middot; <a href="https://guidesly.com" target="_blank">Guidesly</a></p>
@@ -1285,6 +1345,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 22, 2026</h3>
+    <ul>
+      <li><strong>Booking-marketplace competitor gap closed:</strong> added Captain Experiences, Guidesly, and FishingBooker (dual-role) as tracked competitors for PFG&rsquo;s FishIn Buddy roadmap item &mdash; a gap first flagged internally on 2026-07-02 and still open through the July 8 scan. Captain Experiences already lists 28 Arkansas trips / 15+ guides; Guidesly already has live AR lake/river listings. Both are live incumbents, not future risks. 16 competitors now tracked, up from 13.</li>
+      <li><strong>onWater Fish Arkansas-depth verification remains unresolved &mdash; two scans running.</strong> Automated fetch of onwaterapp.com/state/arkansas returned HTTP 403 this scan; still needs a manual, logged-in browser check. Kept as Opportunity #1.</li>
+      <li><strong>Self-description drift fixed:</strong> Lean Canvas and Solution copy still said &ldquo;zero-backend GitHub Pages&rdquo; despite PFG&rsquo;s own CHANGELOG recording the GitHub Pages root retired July 6, 2026 in favor of the Next.js app under `web/` with a Supabase-backed Pocket Score engine. Corrected in the Lean Canvas, Solution, Channels, and Cost Structure cells, and the header badge.</li>
+      <li><strong>No material change confirmed</strong> for onX Fish (still 11 states, Missouri closest to AR, no move since May), Fishial.AI/GilledIt (still Q3 2026, unshipped), and FishGuide AI / Fish AI (no new feature announcements since early July).</li>
+      <li><strong>PFG mentions unchanged:</strong> zero third-party mentions across Reddit, X, forums, press, or app stores this scan &mdash; same result as every prior scan.</li>
+      <li>New Opportunity #9 added: FishIn Buddy needs a guide-acquisition plan against Captain Experiences/Guidesly&rsquo;s existing AR supply, not just a pricing edge.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
- Closes the booking-marketplace competitor gap flagged in the pocket-fishing-guide `docs/SESSION-HANDOFF-2026-07-02.md`: adds **Captain Experiences**, **Guidesly**, and **FishingBooker** (dual editorial/marketplace role) as tracked competitors now that FishIn Buddy (PFG's guide-booking marketplace roadmap item) is active. Both Captain Experiences (28 AR trips, 15+ guides) and Guidesly (multiple live AR lake/river listings) already have established Arkansas guide supply — live incumbents, not future risks.
- Adds Opportunity #9: FishIn Buddy needs a guide-acquisition plan against these incumbents, not just a pricing edge (FishIn Buddy's proposed 100%-to-guide + 9%-angler-fee undercuts Guidesly's 10% and FishingBooker's 10–30% commission on paper).
- Corrects a self-description drift the dashboard had accumulated: Lean Canvas, Solution, Channels, Cost Structure, and the Feature Matrix still described PFG as "zero-backend GitHub Pages" after the product's own CHANGELOG recorded the GitHub Pages root retired July 6, 2026 in favor of the Next.js + Supabase app at `web/`.
- Logs onWater Fish's Arkansas-depth verification as still open — automated fetch of `onwaterapp.com/state/arkansas` returned HTTP 403 this scan; flagged for a manual browser check.
- Confirms no material change since the July 8 scan for onX Fish (still 11 states, Missouri closest to AR), Fishial.AI/GilledIt (still Q3 2026, unshipped), and FishGuide AI / Fish AI.
- 16 competitors now tracked (up from 13). New History tab entry (v1.8).

## Test plan
- [x] Verified competitor-card count (16) matches the summary-bar stat via grep
- [x] Reviewed rendered diff for balanced HTML structure around each edit
- [ ] Open `competitive-dashboard.html` in a browser and click through all 8 tabs, including the 3 new competitor cards' expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiQc72yREGWpjhMbdpToL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiQc72yREGWpjhMbdpToL1)_