### PR TITLE
Update PFG competitive intelligence dashboard — July 23 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 23, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">14</span><span class="stat-label">Tracked Competitors &amp; Allies</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> Arkansas&rsquo;s Office of Outdoor Recreation just launched <strong>Guide ARK</strong>, a free, state-verified guide directory (incl. fishing) promoted on Arkansas.com &mdash; a second official-state partnership target alongside AGFC. Separately, search engines are now surfacing &ldquo;premium upgrade&rdquo; copy (14-day forecasts, big-fish windows, ad-free) on PFG&rsquo;s own site that this dashboard&rsquo;s free-core positioning doesn&rsquo;t currently reflect &mdash; flagged below for a direct human check, since the live site blocked this scan&rsquo;s fetch attempts. onWater Fish&rsquo;s Arkansas-depth verification (opportunity #0) is still outstanding.
   </div>
 </div>
 
@@ -340,6 +340,9 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="warn-box">
     <strong>PFG not found in any major 2026 fishing app roundup.</strong> This is a visibility gap &mdash; not a product gap. The app is not indexed in editorial lists (FishingBooker, GilledIt, Fishbox, Guidesly, Wired2Fish). App store presence and editorial outreach are needed to enter these rankings.
   </div>
+  <div class="warn-box">
+    <strong>Action needed &mdash; unverified this scan:</strong> search-engine snippets for pocketfishinguide.com/waters now describe &ldquo;a premium upgrade option that provides 14-day forecasts, big-fish windows, and an ad-free experience.&rdquo; This dashboard&rsquo;s Lean Canvas and Best Practices rubric both currently score PFG&rsquo;s &ldquo;free core, zero paywall&rdquo; as an A-grade differentiator versus Fishbrain and FishAngler&rsquo;s paywalls. A direct fetch of the live site was blocked (403) this scan, so it&rsquo;s unclear whether this is an already-shipped gated tier or just forward-looking copy for the roadmap&rsquo;s planned Patreon tier. Recommend a human spot-check of pocketfishinguide.com/waters before the next scan &mdash; if real features are now gated, the free-core positioning throughout this dashboard needs to be reconciled with it.
+  </div>
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
@@ -351,12 +354,14 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
         <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
+        <li><strong>Adjacent, not a fishing-app competitor:</strong> BUBBA and Major League Fishing publicly launched SCORETRACKER LIVE (July 13, 2026), consumer tournament-scoring tech tied to BUBBA&rsquo;s Smart Bump Board hardware. Different segment (tournament anglers, hardware-linked) &mdash; logged as a market-heat signal, not a direct threat.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
         <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>New this scan &mdash; needs a human check:</strong> search snippets for pocketfishinguide.com/waters now reference a &ldquo;premium upgrade&rdquo; (14-day forecasts, big-fish windows, ad-free). Direct WebFetch to the live site returned HTTP 403 both at the root domain and /waters, so this could not be confirmed firsthand this scan. See warning box above.</li>
         <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
         <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
         <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
@@ -366,21 +371,22 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
+        <li><strong>New state channel, not an app:</strong> Arkansas&rsquo;s Office of Outdoor Recreation launched <strong>Guide ARK</strong>, a free, state-verified directory of licensed/insured outdoor guides (fishing, hunting, paddling, hiking, climbing, cycling), promoted on Arkansas.com. It overlaps conceptually with PFG&rsquo;s dormant &ldquo;guide profile + sponsor pages&rdquo; roadmap idea and with FishTips&rsquo; guide-authored model &mdash; but as a state program, not a competitor. Second official-Arkansas partnership target alongside AGFC.</li>
         <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
         <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
         <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
         <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
+        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window (still Montana as the most recent new state, May 2026).</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
+        <li><strong>Paywalls and dark patterns are the top complaint, and it&rsquo;s getting worse for competitors, not better.</strong> FishAngler&rsquo;s VIP backlash continues; the team has now added concessions (free 7-day forecasts, marine data/SST/currents) to quiet users rather than reversing the paywall. Separately, <strong>Fish AI</strong>&rsquo;s July 2026 Google Play reviews turned sharply negative &mdash; &ldquo;basically a scam,&rdquo; a reported &euro;85 charge after an unannounced trial conversion, and disputes that its &ldquo;AI&rdquo; catch locations are real. PFG&rsquo;s free, no-dark-pattern model is a genuine and widening differentiator &mdash; contingent on resolving the premium-tier flag above.</li>
         <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
         <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
         <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Two official-Arkansas partnership targets now, not one:</strong> AGFC Mobile (licensing only) and the newly launched Guide ARK directory (guide verification only) both lack a fishing-intelligence layer. A referral or co-promotion from either bypasses organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
       </ul>
     </div>
   </div>
@@ -418,12 +424,30 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Partnership</span></div>
     </div>
   </div>
+  <div class="opp-card priority-high">
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">5</div>
+    <div class="opp-content">
+      <div class="opp-title">Verify PFG&rsquo;s own &ldquo;premium upgrade&rdquo; claim &mdash; new this scan</div>
+      <div class="opp-desc">Search snippets for pocketfishinguide.com/waters now describe a premium tier (14-day forecasts, big-fish windows, ad-free) that this dashboard&rsquo;s free-core positioning doesn&rsquo;t currently account for. A direct fetch was blocked (403) this scan. Confirm with the product team whether this is a shipped gate on previously-free features or just marketing copy for the roadmap&rsquo;s planned Patreon tier, then update the Lean Canvas and Best Practices rubric accordingly.</div>
+      <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Internal Check</span></div>
+    </div>
+  </div>
   <div class="opp-card priority-med">
     <div class="opp-num" style="background:rgba(243,156,18,0.3)">4</div>
     <div class="opp-content">
       <div class="opp-title">Ship education layer before national competition arrives</div>
       <div class="opp-desc">BassForecast + Bass University and Fishbox&rsquo;s AI assistant show the market moving toward skill development. PFG&rsquo;s condition-aware lure scoring is already a teaching tool &mdash; frame it as such. Window: 12&ndash;18 months before a funded player replicates it for Arkansas.</div>
       <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Product</span></div>
+    </div>
+  </div>
+  <div class="opp-card priority-med">
+    <div class="opp-num" style="background:rgba(243,156,18,0.3)">6</div>
+    <div class="opp-content">
+      <div class="opp-title">Apply to the Guide ARK directory</div>
+      <div class="opp-desc">Arkansas&rsquo;s Office of Outdoor Recreation just launched Guide ARK, a free, state-verified directory of outdoor guides promoted on Arkansas.com. While built for individual guides rather than apps, it&rsquo;s a live signal of the state actively curating outdoor-recreation discovery &mdash; worth reaching out to the Office of Outdoor Recreation directly to ask whether an intelligence tool like PFG can be cross-linked or referenced from the directory or Arkansas.com.</div>
+      <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Partnership</span>
+        <a href="https://adpht.arkansas.gov/office-of-outdoor-recreation/guide-ark/" target="_blank" class="badge badge-blue" style="text-decoration:none;">Guide ARK &#x2197;</a>
+      </div>
     </div>
   </div>
 
@@ -459,6 +483,12 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://adpht.arkansas.gov/office-of-outdoor-recreation/guide-ark/" target="_blank">Arkansas Office of Outdoor Recreation &mdash; Guide ARK Directory (launched July 2026)</a></div>
+    <div class="source-item"><a href="https://arkansasoutside.com/guide-ark-directory-verified-outdoor-guides-arkansas/" target="_blank">Arkansas Outside &mdash; Guide ARK Directory Now Live</a></div>
+    <div class="source-item"><a href="https://blog.fishangler.com/new-fishforecast-now-with-more-bite/" target="_blank">FishAngler Blog &mdash; &ldquo;A Smarter Forecast Experience&rdquo; (VIP backlash concessions)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.fishai.app&hl=en_US" target="_blank">Fish AI &mdash; Google Play (July 2026 reviews: billing complaints, disputed AI claims)</a></div>
+    <div class="source-item"><a href="https://majorleaguefishing.com/press-releases/bubba-mlf-officially-launch-scoretracker-live-for-consumers-while-bubba-expands-its-connected-fishing-ecosystem-at-icast-2026/" target="_blank">Major League Fishing / BUBBA &mdash; SCORETRACKER LIVE Launch (July 13, 2026)</a></div>
+    <div class="source-item"><a href="https://www.pocketfishinguide.com/waters" target="_blank">pocketfishinguide.com/waters &mdash; premium-tier copy flagged, direct fetch blocked (403) this scan</a></div>
   </div>
 </div>
 
@@ -623,6 +653,24 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <p><strong>What they do:</strong> Hunting/fishing license purchase, game check submissions, AGFC communication. iOS and Android. Official state endorsement.</p>
         <p style="margin-top:8px;"><strong>Opportunity:</strong> AGFC&rsquo;s app has no fishing intelligence layer. A referral &mdash; &ldquo;for live water conditions, see Pocket Fishing Guide&rdquo; &mdash; would be mutually beneficial. Highest-value partnership target.</p>
         <p style="margin-top:8px;"><a href="https://www.agfc.com/news/agfc-mobile-app-offers-streamlined-license-hunting-experience/" target="_blank">AGFC Mobile &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-guideark')" style="cursor:pointer;">
+        <div><div class="card-title">Guide ARK</div><div class="card-sub">Official AR Guide Directory &middot; New July 2026</div></div>
+        <span class="badge badge-green">Ally Potential &mdash; New</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Competitive Overlap</span><span>Minimal</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:10%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">AR Official</span><span class="tag">Guide Verification</span><span class="tag">Free</span><span class="tag">Arkansas.com</span></div>
+      <div id="d-guideark" class="details-panel">
+        <p><strong>What they do:</strong> Arkansas&rsquo;s Office of Outdoor Recreation launched a free, state-verified directory of licensed and insured outdoor guides &mdash; hunting, fishing, paddling, hiking, climbing, cycling &mdash; promoted through Arkansas.com. Guides apply at no cost; the state vets and features them for tourists actively planning trips.</p>
+        <p style="margin-top:8px;"><strong>Overlap:</strong> Not a fishing-intelligence app &mdash; a guide-verification directory. Conceptually adjacent to FishTips&rsquo; guide model and to PFG&rsquo;s dormant &ldquo;guide profile + sponsor pages&rdquo; roadmap idea.</p>
+        <p style="margin-top:8px;"><strong>Opportunity:</strong> A second official-state channel alongside AGFC. Worth asking the Office of Outdoor Recreation whether an intelligence tool (not a guide service) can be referenced from the directory or Arkansas.com &mdash; unverified whether that&rsquo;s in scope for the program.</p>
+        <p style="margin-top:8px;"><a href="https://adpht.arkansas.gov/office-of-outdoor-recreation/guide-ark/" target="_blank">Guide ARK &#x2197;</a></p>
       </div>
     </div>
 
@@ -1160,7 +1208,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">Partnership &amp; Co-Marketing</div>
-      <div class="rubric-desc">AGFC Mobile is the highest-value potential partner &mdash; official state fishing authority with the exact target audience. Tackle shops, fishing guides, and AR outdoor media are secondary targets. Zero active partnerships exist currently.</div>
+      <div class="rubric-desc">AGFC Mobile is the highest-value potential partner &mdash; official state fishing authority with the exact target audience. The newly launched Guide ARK directory (Arkansas Office of Outdoor Recreation, July 2026) is a second official-state channel worth approaching. Tackle shops, fishing guides, and AR outdoor media remain secondary targets. Zero active partnerships exist currently.</div>
       <div class="rubric-score score-c">C</div>
     </div>
     <div class="rubric-row">
@@ -1285,6 +1333,17 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 23, 2026</h3>
+    <ul>
+      <li><strong>New partnership target: Guide ARK.</strong> Arkansas&rsquo;s Office of Outdoor Recreation launched a free, state-verified outdoor-guide directory (incl. fishing) promoted on Arkansas.com. Not a competitor &mdash; a second official-state channel alongside AGFC. Added as a new tracked &ldquo;Ally Potential&rdquo; card and a new Opportunity item. Tracked count: 14, up from 13.</li>
+      <li><strong>Action flagged, unresolved this scan:</strong> search-engine snippets for pocketfishinguide.com/waters now describe a &ldquo;premium upgrade&rdquo; (14-day forecasts, big-fish windows, ad-free) that this dashboard&rsquo;s free-core positioning doesn&rsquo;t currently reflect. Direct WebFetch to both the root domain and /waters returned HTTP 403 this scan, so it could not be confirmed firsthand whether this is a shipped gate or forward-looking roadmap copy. Added as a High Priority &ldquo;Internal Check&rdquo; opportunity and a warning box in the Intelligence Report &mdash; needs a human spot-check before the next scan.</li>
+      <li><strong>Competitor sentiment update:</strong> FishAngler&rsquo;s VIP backlash continues; the team is now offering concessions (free 7-day forecasts, marine data/SST/currents) rather than reversing the paywall. Fish AI&rsquo;s July 2026 Google Play reviews turned sharply negative &mdash; &ldquo;basically a scam,&rdquo; an unannounced trial-to-paid conversion charge, and disputes that its AI-sourced catch locations are genuine. Both reinforce PFG&rsquo;s free/no-dark-pattern positioning as a widening differentiator, contingent on resolving the premium-tier flag above.</li>
+      <li><strong>Adjacent market signal, not a direct threat:</strong> BUBBA/Major League Fishing publicly launched SCORETRACKER LIVE (July 13, 2026), consumer tournament-scoring tech tied to hardware (Smart Bump Board). Different segment (tournament anglers) &mdash; logged for market-heat awareness only.</li>
+      <li><strong>Unchanged this window:</strong> onX Fish still tops out at Montana (May 2026), no further move toward Arkansas/Missouri. GilledIt&rsquo;s Fishial.AI integration remains on track for Q3 2026, unshipped. onWater Fish&rsquo;s Arkansas data-depth verification (Opportunity #0) is still outstanding &mdash; no new public information changed its status this scan. PFG still has zero third-party mentions on Reddit, X, forums, press, or app stores; still absent from every 2026 editorial roundup.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
Routine competitive/market monitoring scan for Pocket Fishing Guide, bumping `competitive-dashboard.html` from v1.7 → v1.8.

- **New partnership target:** Arkansas's Office of Outdoor Recreation launched **Guide ARK**, a free, state-verified outdoor-guide directory (incl. fishing) promoted on Arkansas.com — added as a new "Ally Potential" card and Opportunity item, alongside AGFC.
- **Flagged for human verification:** search-engine snippets for `pocketfishinguide.com/waters` now describe a "premium upgrade" (14-day forecasts, big-fish windows, ad-free) that the dashboard's current "free core, zero paywall" positioning doesn't reflect. Direct WebFetch to the live site returned HTTP 403 (both root and `/waters`), so this could not be confirmed firsthand this scan — added as a High Priority "Internal Check" opportunity and a new warning box in the Intelligence Report tab.
- **Sentiment updates:** FishAngler's VIP paywall backlash continues (team now offering concessions rather than reversing course); Fish AI's July 2026 Google Play reviews turned sharply negative (billing complaints, disputed AI-sourced catch locations).
- **Market-heat signal (not a direct threat):** BUBBA/Major League Fishing publicly launched SCORETRACKER LIVE (July 13, 2026) — tournament-scoring tech tied to hardware, different segment.
- **Unchanged this window:** onX Fish still tops out at Montana; GilledIt's Fishial.AI integration still on track for Q3 2026, unshipped; onWater Fish's Arkansas data-depth verification (Opportunity #0) still outstanding; PFG still has zero third-party mentions and zero editorial roundup presence.
- Appended a new `v1.8 · July 23, 2026` entry to the append-only History tab; tracked-competitor/ally count bumped 13 → 14.

## Test plan
- [x] Verified `<div>` open/close tag balance (483/483) after edits
- [x] Spot-checked new cards, opportunity items, and sources render inside existing tab/accordion structure
- [ ] Visual check in browser recommended before merge (no build step for this static site)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JiFZbRtewV9Ar76Jr8mwEQ)_