### PR TITLE
Update PFG competitive intelligence dashboard — July 24 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 24, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">14</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> Quiet window competitively (July 8&ndash;24) &mdash; no new direct bite-prediction/AI competitors, and PFG is still absent from every third-party source checked (Reddit, editorial roundups, social). Two actionable findings surfaced instead: PFG&rsquo;s own live site shows a <strong>conflicting water count (39 vs. 57) across pages</strong> &mdash; a same-day QA fix &mdash; and AGFC&rsquo;s new 2026&ndash;27 guidebook (reduced trout limits on 4 tailwaters, Lake Monticello harvest reopened) is a ready-made, zero-cost content opportunity on PFG&rsquo;s home turf. Also newly tracked: <strong>BUBBA &times; MLF SCORETRACKER LIVE</strong>, a nationwide tournament-scoring app with a hardware-integrated Smart Bump Board, launched July 13 &mdash; a gamification entrant to watch, not a direct threat.
   </div>
 </div>
 
@@ -343,44 +343,41 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 8&ndash;24, 2026</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>No new direct bite-prediction/AI fishing competitors found this window.</strong> Searches for new app launches, AI fishing tools, and Arkansas-specific guide apps turned up nothing that wasn&rsquo;t already tracked.</li>
+        <li><strong>BUBBA &times; MLF SCORETRACKER LIVE &mdash; official consumer launch, July 13, 2026 (added as 14th tracked entrant).</strong> Timed to the ICAST Cup, now live nationwide for tournament organizers, competitors, and fans; supports catch-weigh-release, five-fish, big-fish, and team formats, citing 91,000+ hours of prior live MLF scoring. Paired with a new <strong>BUBBA Pro Series Smart Bump Board</strong> hardware accessory that auto-captures fish length for the app. Tournament/gamification-adjacent, not a bite-prediction or intelligence-layer competitor.</li>
+        <li><strong>Mallard Bay Outdoors acquired Find A Hunt (and sister brand Find A Fish)</strong>, ~July 7 &mdash; a booking/marketplace consolidation for discovering and booking guided outdoor experiences, not an intelligence app. Logged as adjacent-market, not a direct competitor.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Still zero third-party mentions &mdash; reconfirmed more thoroughly this window.</strong> Direct-search queries for &ldquo;Pocket Fishing Guide,&rdquo; &ldquo;PocketFishingGuide,&rdquo; and &ldquo;pocketfishinguide.com&rdquo; return only PFG&rsquo;s own indexed pages (per-water landing pages like /water/wb_lake_chicot). A dedicated <code>site:reddit.com</code> search returned nothing at all, not even unrelated noise.</li>
+        <li><strong>New QA finding: conflicting water counts on the live site.</strong> PFG&rsquo;s own page copy cites &ldquo;39 waters&rdquo; in one place and &ldquo;57 waters&rdquo; in another &mdash; worth a same-day fix since it&rsquo;s the one piece of PFG copy that <em>is</em> being indexed and read.</li>
+        <li><strong>New finding: brand-name collision risk.</strong> Generic &ldquo;pocket fishing guide&rdquo;-style searches surface an unrelated, poorly-reviewed Nintendo Switch game (&ldquo;Pocket Fishing&rdquo;) and a UK App Store app (&ldquo;Pocket Guide UK Sea Fishing Lite&rdquo;) that can dilute branded search results. Not actionable beyond awareness.</li>
+        <li><strong>Still zero editorial mentions,</strong> reconfirmed against Kayak Angler, Fishbox, Guidesly, GilledIt, and FishingBooker&rsquo;s 2026 roundups.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
-        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
+        <li><strong>Tournament/competitive gamification just got a major nationwide entrant</strong> in BUBBA &times; MLF SCORETRACKER LIVE, reinforcing that the industry&rsquo;s progression mechanics remain competition-framed, not educational &mdash; PFG&rsquo;s beginner&rarr;expert education path is still unclaimed white space.</li>
+        <li><strong>GilledIt&rsquo;s Fishial.AI photo ID remains unshipped,</strong> still targeting Q3 2026 &mdash; unchanged from last scan, but Q3 starts within the next cycle or two, so this needs a recheck soon.</li>
+        <li><strong>Fish AI is drawing fresh negative sentiment</strong> despite a 4.7/5 aggregate rating (18.7K reviews): a July 20, 2026 review flagged it as &ldquo;buggy,&rdquo; with recurring complaints about deceptive subscription practices. A useful contrast point for PFG&rsquo;s free, transparent-pricing messaging.</li>
+        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI remain the live AI-forward products to watch; no new entrants this window. PFG&rsquo;s planned Claude API assistant should stay condition-aware and AGFC-cited to avoid reading as a generic AI fishing chatbot.</li>
+        <li><strong>Android expansion:</strong> onX Fish confirmed still at 11 states (Missouri remains the nearest to Arkansas) &mdash; no new states added this window.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>New, zero-cost content opportunity: AGFC&rsquo;s 2026&ndash;27 Fishing Guidebook,</strong> effective July 1, 2026 &mdash; reduced trout catch limits on four major tailwaters (following a 2025 hatchery flood at Jim Hinkle Spring River State Fish Hatchery) and Lake Monticello moving from catch-and-release to new harvest allowances. This is squarely on PFG&rsquo;s home turf and no tracked competitor has surfaced it as content; a &ldquo;know the new rules&rdquo; feature or post is a same-week opportunity.</li>
+        <li><strong>Third-party market-size figures remain inconsistent across sources</strong> &mdash; from $217M (2026, matching the dashboard&rsquo;s $0.22B/11.68% CAGR figure) up to $2.35B and separately $1.3&ndash;2.1B by 2032 cited elsewhere. Treating the more granular $217M/11.68% CAGR figure as the working number; flagging the spread as a caveat rather than switching numbers again.</li>
+        <li><strong>ICAST 2026&rsquo;s New Product Showcase winners (announced July 20)</strong> skewed entirely toward hardware (rods, reels, Garmin LiveScope 2 HD) &mdash; no app or software award category was identified. Fishing-industry innovation attention isn&rsquo;t yet on software at the trade-show level, which leaves room for a digital-intelligence player like PFG to stand out precisely because so few competitors are investing there publicly.</li>
+        <li><strong>Paywalls remain the top complaint</strong> across 2026 reviews (Fishbrain, FishAngler VIP, and now recurring Fish AI subscription complaints) &mdash; PFG&rsquo;s free model is a genuine, reinforced differentiator.</li>
+        <li><strong>Record participation, record churn</strong> (RBFF/ASA, no update this window): 57.9M US anglers in 2024, 23% one-year churn &mdash; still the strongest data-backed case for PFG&rsquo;s planned retention/onboarding work.</li>
       </ul>
     </div>
   </div>
@@ -426,6 +423,22 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Product</span></div>
     </div>
   </div>
+  <div class="opp-card priority-high">
+    <div class="opp-num" style="background:rgba(192,57,43,0.3)">5</div>
+    <div class="opp-content">
+      <div class="opp-title">Fix the water-count inconsistency on the live site</div>
+      <div class="opp-desc">This scan&rsquo;s search snippets show PFG&rsquo;s own page copy citing &ldquo;39 waters&rdquo; in one place and &ldquo;57 waters&rdquo; in another. This is the one piece of PFG copy currently being indexed and read by outside search &mdash; a same-day fix, zero cost, and it&rsquo;s live right now.</div>
+      <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Quick Win &middot; $0</span></div>
+    </div>
+  </div>
+  <div class="opp-card priority-med">
+    <div class="opp-num" style="background:rgba(243,156,18,0.3)">6</div>
+    <div class="opp-content">
+      <div class="opp-title">Publish a &ldquo;new 2026&ndash;27 AGFC rules&rdquo; content piece</div>
+      <div class="opp-desc">AGFC&rsquo;s new guidebook (effective July 1, 2026) cut trout limits on four major tailwaters and reopened harvest at Lake Monticello &mdash; real, timely, Arkansas-specific news that no tracked competitor has covered. A short &ldquo;know before you go&rdquo; regulations update ties directly to PFG&rsquo;s tagline and is a zero-cost, high-relevance content opportunity.</div>
+      <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Content &middot; $0</span></div>
+    </div>
+  </div>
 
   <div class="section-title" style="margin-top:24px;"><span class="icon">&#x1F517;</span>Sources</div>
   <div class="sources-list">
@@ -459,6 +472,14 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://majorleaguefishing.com/press-releases/bubba-mlf-officially-launch-scoretracker-live-for-consumers-while-bubba-expands-its-connected-fishing-ecosystem-at-icast-2026/" target="_blank">Major League Fishing &mdash; BUBBA x MLF SCORETRACKER LIVE Consumer Launch (July 13, 2026)</a></div>
+    <div class="source-item"><a href="https://www.travelandtourworld.com/news/article/jju5w21x1drl/" target="_blank">Mallard Bay Outdoors Acquires Find A Hunt / Find A Fish (July 2026)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/com-fishai-app" target="_blank">Fish AI &mdash; Sentiment Report (4.7/5, polarized, July 20 2026 review)</a></div>
+    <div class="source-item"><a href="https://www.gilledit.com/compare/fishbuddy" target="_blank">GilledIt vs. Fishbuddy &mdash; Fishial.AI Q3 2026 Confirmation</a></div>
+    <div class="source-item"><a href="https://www.agfc.com/news/arkansas-2026-27-fishing-regulations-changes-in-effect-new-guidebook-released/" target="_blank">AGFC &mdash; 2026&ndash;27 Fishing Guidebook, Regulation Changes</a></div>
+    <div class="source-item"><a href="https://www.agfc.com/news/trout-lake-monticello-regulations-most-notable-changes-in-2026-arkansas-fishing-guidebook/" target="_blank">AGFC &mdash; Trout &amp; Lake Monticello Regulation Changes Detail</a></div>
+    <div class="source-item"><a href="https://gearjunkie.com/fishing/biggest-winners-icast-2026-new-product-showcase" target="_blank">GearJunkie &mdash; ICAST 2026 New Product Showcase Winners (July 20)</a></div>
+    <div class="source-item"><a href="https://www.datainsightsreports.com/reports/fishing-app-market-2981" target="_blank">Data Insights Reports &mdash; Fishing App Market Sizing (conflicting figures)</a></div>
   </div>
 </div>
 
@@ -695,6 +716,24 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions rather than scoring real water data. Worth a quarterly recheck in case one adds state-level intelligence.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware and Arkansas-specific to avoid competing head-on with these generalists.</p>
         <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a></p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-bubbamlf')" style="cursor:pointer;">
+        <div><div class="card-title">BUBBA &times; MLF SCORETRACKER LIVE</div><div class="card-sub">Tournament Scoring &middot; Hardware-Integrated</div></div>
+        <span class="badge badge-muted">Low Threat</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>Low (different use case)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:15%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Tournament Scoring</span><span class="tag">Hardware Add-On</span><span class="tag">Gamification</span><span class="tag">No Local Data</span></div>
+      <div id="d-bubbamlf" class="details-panel">
+        <p><strong>What it does:</strong> Official consumer launch, July 13, 2026, timed to the ICAST Cup. Nationwide tournament-scoring app for organizers, competitors, and fans, supporting catch-weigh-release, five-fish, big-fish, and team formats, built on 91,000+ hours of prior live MLF event scoring. Paired with a new BUBBA Pro Series Smart Bump Board that auto-captures fish length for the app.</p>
+        <p style="margin-top:8px;"><strong>Threat:</strong> Low and indirect &mdash; this is a competitive-tournament tool, not a bite-prediction or water-intelligence app, and has no Arkansas-specific or condition-aware data. Worth tracking as evidence that gamification/competition mechanics are getting real investment industry-wide, reinforcing that PFG&rsquo;s education-first angle stays differentiated rather than competing head-on.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> No overlap on core value (real-time condition scoring for everyday anglers vs. tournament scorekeeping). No action needed beyond awareness.</p>
+        <p style="margin-top:8px;"><a href="https://majorleaguefishing.com/press-releases/bubba-mlf-officially-launch-scoretracker-live-for-consumers-while-bubba-expands-its-connected-fishing-ecosystem-at-icast-2026/" target="_blank">MLF press release &#x2197;</a></p>
       </div>
     </div>
 
@@ -1285,6 +1324,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 24, 2026</h3>
+    <ul>
+      <li><strong>Quiet window for direct competition</strong> (July 8&ndash;24): no new bite-prediction/AI fishing competitors found, and PFG remains absent from every third-party channel checked &mdash; Reddit, editorial roundups, social. A dedicated <code>site:reddit.com</code> search returned zero results outright.</li>
+      <li><strong>BUBBA &times; MLF SCORETRACKER LIVE added as 14th tracked entrant</strong> &mdash; official nationwide consumer launch July 13, 2026, tournament-scoring app (catch-weigh-release, five-fish, big-fish, team formats) paired with a new BUBBA Pro Series Smart Bump Board hardware accessory. Logged Low threat: tournament/gamification-adjacent, not a bite-prediction or intelligence-layer competitor.</li>
+      <li><strong>Mallard Bay Outdoors acquired Find A Hunt / Find A Fish</strong> (~July 7) &mdash; a booking/marketplace consolidation, adjacent market, not a direct competitor.</li>
+      <li><strong>New QA finding on PFG&rsquo;s own site:</strong> page copy cites conflicting water counts (&ldquo;39 waters&rdquo; vs. &ldquo;57 waters&rdquo;) &mdash; flagged as a same-day fix since it&rsquo;s the one piece of PFG copy currently being indexed by outside search. Added as a new high-priority Quick Win opportunity.</li>
+      <li><strong>New content opportunity:</strong> AGFC&rsquo;s 2026&ndash;27 Fishing Guidebook (effective July 1) cut trout limits on four tailwaters and reopened Lake Monticello harvest &mdash; timely, Arkansas-specific, zero-cost content no competitor has covered. Added as a new opportunity card.</li>
+      <li><strong>Fish AI</strong> drawing fresh negative sentiment (4.7/5 aggregate but a July 20 &ldquo;buggy&rdquo; review and recurring deceptive-subscription complaints) despite no version change; <strong>GilledIt&rsquo;s Fishial.AI</strong> still unshipped, Q3 2026 target unchanged; <strong>onX Fish</strong> still at 11 states, no move toward Arkansas.</li>
+      <li>Noted brand-name collision risk (unrelated &ldquo;Pocket Fishing&rdquo; Switch game, &ldquo;Pocket Guide UK Sea Fishing Lite&rdquo; app) and inconsistent third-party fishing-app market-size estimates ($217M&ndash;$2.35B spread) &mdash; both logged as caveats, not actioned.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary
Routine competitive/market-landscape scan for Pocket Fishing Guide, covering the gap since the last scan (v1.7, July 8, 2026).

- **Quiet window for direct competition** (July 8–24): no new bite-prediction/AI fishing competitors found, and PFG remains absent from every third-party channel checked (Reddit, editorial roundups, social) — reconfirmed more thoroughly than prior scans.
- **BUBBA × MLF SCORETRACKER LIVE** added as 14th tracked entrant — official nationwide tournament-scoring app launch (July 13), paired with a hardware-integrated Smart Bump Board. Logged Low threat (gamification-adjacent, not a bite-prediction/intelligence competitor).
- **Mallard Bay Outdoors** acquired Find A Hunt / Find A Fish (~July 7) — logged as an adjacent-market signal, not a direct competitor.
- **New QA finding:** PFG's own live site shows conflicting water counts ("39 waters" vs. "57 waters") across pages — added as a new high-priority Quick Win opportunity card.
- **New content opportunity:** AGFC's 2026–27 Fishing Guidebook (effective July 1) cut trout limits on four tailwaters and reopened Lake Monticello harvest — a timely, zero-cost, Arkansas-specific content angle no competitor has covered. Added as a new Medium-priority opportunity card.
- Logged Fish AI's fresh negative sentiment (July 20 "buggy" review, recurring subscription complaints) and a brand-name collision risk with unrelated "Pocket Fishing" products, as caveats.
- Header/version bumped to v1.8, July 24, 2026; new dated entry appended to the History tab per the existing append-only pattern.

## Test plan
- [x] Verified `<div>` tag balance (484 open / 484 close) after edits
- [x] Verified pushed file size matches local edited file byte-for-byte (108,882 bytes)
- [ ] Manual visual check in browser (tabs, new BUBBA card, new opportunity cards) — recommend before merge

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Szn6w9g2LjbXz8DwqmnNta

---
_Generated by [Claude Code](https://claude.ai/code/session_01Szn6w9g2LjbXz8DwqmnNta)_