### PR TITLE
[Feature] Competitive dashboard v1.8 — July 29, 2026 scan update

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 29, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -311,13 +311,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 </div>
 
 <div class="summary-bar">
-  <div class="stat"><span class="stat-val">13</span><span class="stat-label">Tracked Competitors</span></div>
+  <div class="stat"><span class="stat-val">14</span><span class="stat-label">Tracked Competitors</span></div>
   <div class="stat"><span class="stat-val">$0.22B</span><span class="stat-label">Market Size (2026)</span></div>
   <div class="stat"><span class="stat-val">11.68%</span><span class="stat-label">CAGR</span></div>
-  <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
+  <div class="stat"><span class="stat-val">57</span><span class="stat-label">PFG AR Waters (was 39)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> PFG quietly closed real product gaps this window &mdash; a full Next.js/Supabase migration, a &ldquo;why this score&rdquo; Pocket-Score verdict engine, user catch reports, and a statewide Weekly Report &mdash; while the visibility side stood still: still zero third-party mentions anywhere, and two more 2026 roundups (Hook &amp; Barrel, Wish Upon A Fish) confirmed to exclude PFG. New AI-native bass competitor <strong>Deep Dive</strong> (Bassmaster/MLF pro-intel) added to tracking. onWater Fish&rsquo;s actual Arkansas data depth is still unverified &mdash; its site blocked a direct check this scan too.
   </div>
 </div>
 
@@ -338,49 +338,46 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <div id="tab-report" class="tab-panel active">
 
   <div class="warn-box">
-    <strong>PFG not found in any major 2026 fishing app roundup.</strong> This is a visibility gap &mdash; not a product gap. The app is not indexed in editorial lists (FishingBooker, GilledIt, Fishbox, Guidesly, Wired2Fish). App store presence and editorial outreach are needed to enter these rankings.
+    <strong>PFG not found in any of 8 major 2026 fishing app roundups checked to date.</strong> This is a visibility gap &mdash; not a product gap, and the gap is widening even as the product improves. Not indexed in FishingBooker, GilledIt, Fishbox, Guidesly, Wired2Fish, Kayak Angler, Hook &amp; Barrel, or Wish Upon A Fish. App store presence and editorial outreach are needed to enter these rankings.
   </div>
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 29 Scan</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>Deep Dive (Bass Fishing App) added to tracking.</strong> A pro-intelligence bass app &mdash; not community-sourced &mdash; featured live on Bassmaster, MLF, and NPFL tournament broadcasts: satellite water-clarity lake maps, a proprietary bait/lure recommendation tool, 7-day hyper-local forecasts and bite times, real-time lake level/stream flow tracking, and dam generation-release schedules for TVA lakes. Free to download with a Deep Dive Pro tier. No Arkansas-specific coverage identified (its dam-schedule depth is built around TVA lakes, which don&rsquo;t reach Arkansas), but it is a legitimate AI-native, bass-focused overlap with PFG&rsquo;s White Bass intelligence and worth a recheck if it expands to Corps-of-Engineers lakes.</li>
+        <li><strong>onWater Fish&rsquo;s Arkansas data depth remains unverified for a second scan running.</strong> A direct hands-on check (this scan&rsquo;s top-priority action item from July 8) was attempted but its site returned a bot-protection block; general 2026 coverage of &ldquo;Angler Intelligence&trade;&rdquo; found (e.g. a Sports Illustrated field test) covers Florida, not Arkansas. Still an open item, now carried a second time &mdash; escalate to a manual/in-app check rather than a repeated site fetch.</li>
+        <li><strong>onX Fish and GilledIt&rsquo;s Fishial.AI unchanged this window</strong> &mdash; no new state expansion beyond Montana (May 2026), and photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>FishAngler VIP backlash continues, with a partial company walk-back.</strong> FishAngler publicly acknowledged the paywall frustration and added some free 7-day forecasts, marine data, SST, and currents back as a concession &mdash; but the solunar calendar and full FishForecast still sit behind VIP. Reviews still cite a clunkier redesign (chopped-off labels, missing tide info).</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Still zero third-party mentions anywhere.</strong> Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings again returned only the product&rsquo;s own site (pocketfishinguide.com) or unrelated print books that happen to share the &ldquo;pocket fishing guide&rdquo; name &mdash; unchanged since tracking began three scans ago.</li>
+        <li><strong>Two additional 2026 editorial roundups discovered and checked &mdash; PFG absent from both.</strong> Hook &amp; Barrel Magazine (&ldquo;Best Hunting and Fishing Apps... for 2026&rdquo;, features Deep Dive) and Wish Upon A Fish (&ldquo;32 Best Fishing Apps for 2026&rdquo;). Neither mentions PFG. The roundup universe PFG needs to break into has grown from 6 to 8 tracked outlets without a single inclusion.</li>
+        <li><strong>AGFC Mobile</strong> still dominates Arkansas fishing-app search results &mdash; licensing-only, no intelligence layer.</li>
+        <li><strong>FishTips and onWater Fish</strong> continue to out-rank PFG for Arkansas-specific fishing-app queries.</li>
       </ul>
     </div>
     <div class="report-block">
-      <h3>Competitor Moves vs. PFG Roadmap</h3>
+      <h3>PFG&rsquo;s Own Roadmap Execution This Window</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
-        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
+        <li><strong>Full migration off the legacy static site to a production Next.js app on Vercel with a Supabase catalog</strong> (committed JSON mirrors kept as a resilient fallback). The old single-file `index.html`/`app.html` experience is now archived; `paddler.html` remains the one live static surface.</li>
+        <li><strong>Water count corrected from 39 to 57 Arkansas water bodies (33 species)</strong> &mdash; this dashboard&rsquo;s prior &ldquo;39-body&rdquo; figure was stale; the real shipped catalog is materially larger.</li>
+        <li><strong>Shipped: Pocket Score verdict engine</strong> &mdash; blends live USGS/NWS/AGFC-corroborated signal math into a GO/SCOUT/HOLD verdict with a contributor breakdown and a one-line &ldquo;why,&rdquo; surfaced on a new statewide Weekly Report route and per-water Reports tabs. This is a direct, shipped answer to last scan&rsquo;s Opportunity #5 (&ldquo;why this lure&rdquo; explanations) and the Onboarding &amp; Education rubric gap.</li>
+        <li><strong>Shipped: user-submitted catch reports</strong> (photo submit, EXIF strip/verify, moderation queue &mdash; ADR-014 Phases A &amp; B) &mdash; first real progress on the &ldquo;Community / social catch log&rdquo; feature-matrix row, though still short of GilledIt/Fishbrain/FishAngler&rsquo;s full social feeds.</li>
+        <li><strong>No movement yet</strong> on App Store/Google Play distribution, AGFC partnership outreach, or editorial pitching &mdash; these remain the binding visibility constraints regardless of product progress.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Paywalls remain the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s VIP tier are still the most-cited negatives in 2026 reviews, even after FishAngler&rsquo;s partial free-feature concession. PFG&rsquo;s free model, now backed by a materially bigger shipped product, is a stronger differentiator than it was three scans ago.</li>
+        <li><strong>No new market-size or churn data this window</strong> &mdash; RBFF/ASA 2025 figures (57.9M anglers, 23% churn) remain the latest available and still support PFG&rsquo;s retention-focused roadmap direction.</li>
+        <li><strong>Local depth wins &mdash; the field is crowded but PFG just got materially deeper.</strong> No competitor combines 57 Arkansas water bodies, real-time USGS/NWS/AGFC-fused scoring, and now a &ldquo;why&rdquo; verdict engine. onWater Fish and FishTips both claim Arkansas presence, but neither has confirmed matching depth.</li>
+        <li><strong>The gap between product and visibility is now the widest it has been.</strong> Three scans of real shipped progress (Pocket Score, catch reports, Weekly Report, full platform migration) against zero change in third-party visibility. The next scan&rsquo;s highest-leverage check is whether any outreach (editorial, AGFC, app store) has actually started &mdash; not whether more features ship.</li>
       </ul>
     </div>
   </div>
@@ -389,9 +386,9 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-high">
     <div class="opp-num" style="background:rgba(192,57,43,0.3)">0</div>
     <div class="opp-content">
-      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; do this first</div>
-      <div class="opp-desc">onWater Fish now brands itself &ldquo;the First AI-Native Fishing Experience&rdquo; and already runs live Arkansas pages, but its data depth on AR specifically (AGFC integration, spawn-phase science, condition-aware scoring) is unverified from the outside. Spend 30 minutes in the actual app/site on an Arkansas water and document what it does and doesn&rsquo;t do versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language &mdash; the difference changes how urgently the rest of this list should move.</div>
-      <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span></div>
+      <div class="opp-title">Hands-on review of onWater Fish&rsquo;s Arkansas depth &mdash; carried over a second scan, do this first</div>
+      <div class="opp-desc">Two scans running, this item has not been closed &mdash; an automated site check keeps getting blocked, which is exactly why it needs a human 30 minutes in the actual app on an Arkansas water, not another fetch attempt. Document what onWater does and doesn&rsquo;t do (AGFC integration, spawn-phase science, condition-aware scoring) versus PFG. This determines whether onWater is a real structural threat or a shallow-coverage app wearing PFG&rsquo;s positioning language.</div>
+      <div class="opp-meta"><span class="badge badge-red">High Priority</span><span class="badge badge-muted">Competitive Intel</span><span class="badge badge-muted">Carried Over</span></div>
     </div>
   </div>
   <div class="opp-card priority-high">
@@ -421,9 +418,9 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="opp-card priority-med">
     <div class="opp-num" style="background:rgba(243,156,18,0.3)">4</div>
     <div class="opp-content">
-      <div class="opp-title">Ship education layer before national competition arrives</div>
-      <div class="opp-desc">BassForecast + Bass University and Fishbox&rsquo;s AI assistant show the market moving toward skill development. PFG&rsquo;s condition-aware lure scoring is already a teaching tool &mdash; frame it as such. Window: 12&ndash;18 months before a funded player replicates it for Arkansas.</div>
-      <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Product</span></div>
+      <div class="opp-title">Extend the new Pocket Score &ldquo;why&rdquo; reasoning into a real education layer</div>
+      <div class="opp-desc"><strong>Partially shipped this window:</strong> the new Pocket Score engine already surfaces a one-line &ldquo;why&rdquo; and a contributor breakdown per verdict &mdash; the exact mechanic this recommendation asked for last scan. The remaining gap is turning that into structured, beginner&rarr;expert content (a real curriculum), which BassForecast&rsquo;s Bass University partnership and Fishbox&rsquo;s AI assistant both monetize. Window: 12&ndash;18 months before a funded player replicates it for Arkansas.</div>
+      <div class="opp-meta"><span class="badge badge-amber">Medium Priority</span><span class="badge badge-muted">Product</span><span class="badge badge-green" style="background:rgba(46,125,82,0.25); color:#5dd08a; border:1px solid rgba(46,125,82,0.5);">In Progress</span></div>
     </div>
   </div>
 
@@ -459,6 +456,12 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://deepdiveapp.com/" target="_blank">Deep Dive &mdash; Bass Fishing App (Bassmaster/MLF/NPFL pro intel)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=com.fishingai&amp;hl=en_US" target="_blank">Deep Dive &mdash; Google Play Listing</a></div>
+    <div class="source-item"><a href="https://www.hookandbarrel.com/gear/hunting-and-fishing-apps-2026" target="_blank">Hook &amp; Barrel Magazine &mdash; Best Hunting and Fishing Apps for 2026 (new roundup, checked, no PFG)</a></div>
+    <div class="source-item"><a href="https://www.wishuponafish.com/article/best-fishing-apps" target="_blank">Wish Upon A Fish &mdash; 32 Best Fishing Apps for 2026 (new roundup, checked, no PFG)</a></div>
+    <div class="source-item"><a href="https://www.si.com/onsi/fishing/bass-fishing/ai-fishing-app-tested-with-bass-pro" target="_blank">Sports Illustrated &mdash; AI Fishing App Tested With a Bass Pro (onWater field test, Florida not Arkansas)</a></div>
+    <div class="source-item"><a href="https://blog.fishangler.com/fishangler-vip/" target="_blank">FishAngler Blog &mdash; VIP concession (free 7-day forecast, marine data added back)</a></div>
   </div>
 </div>
 
@@ -698,6 +701,24 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
     </div>
 
+    <div class="card">
+      <div class="card-header" onclick="toggleDetails('d-deepdive')" style="cursor:pointer;">
+        <div><div class="card-title">Deep Dive</div><div class="card-sub">Pro-Intel Bass App &middot; Bassmaster/MLF Featured</div></div>
+        <span class="badge badge-amber">Watch &mdash; New</span>
+      </div>
+      <div class="threat-meter">
+        <div class="threat-label"><span>Threat to PFG</span><span>Low&ndash;Medium (different segment, no AR presence)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-medium" style="width:30%"></div></div>
+      </div>
+      <div class="tags"><span class="tag">Pro Intel</span><span class="tag">Bass-Specific</span><span class="tag">Satellite Clarity Maps</span><span class="tag">TVA Dam Schedules</span><span class="tag">Free/Pro</span></div>
+      <div id="d-deepdive" class="details-panel">
+        <p><strong>What they do:</strong> A bass-only app built entirely on pro tournament intelligence rather than crowd-sourced reports &mdash; featured live on Bassmaster, MLF, and NPFL broadcasts. Satellite-powered water clarity lake maps, a proprietary bait/lure recommendation tool, 7-day hyper-local forecasts and bite times, real-time lake level/stream flow tracking, and dam generation-release schedules for TVA (Tennessee Valley Authority) lakes. Free download; Deep Dive Pro unlocks advanced map layers and premium tournament data.</p>
+        <p style="margin-top:8px;"><strong>Overlap:</strong> Directly relevant to PFG&rsquo;s White Bass intelligence and condition-aware lure scoring &mdash; same underlying problem, tournament-pro framing instead of local-beginner framing. No Arkansas-specific coverage found; its dam-release depth is built around TVA lakes, which don&rsquo;t reach Arkansas (AR reservoirs are mostly Corps of Engineers-managed).</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Free-forever, Arkansas-native, beginner-friendly framing vs. Deep Dive&rsquo;s tournament-pro positioning and Pro paywall. Worth a recheck if Deep Dive ever adds Corps-of-Engineers lake coverage.</p>
+        <p style="margin-top:8px;"><a href="https://deepdiveapp.com/" target="_blank">deepdiveapp.com &#x2197;</a></p>
+      </div>
+    </div>
+
   </div>
 </div>
 
@@ -719,119 +740,120 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
           <th>BassForecast</th>
           <th>Fishbox</th>
           <th>AGFC</th>
+          <th>Deep Dive</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td class="feature-name">Arkansas-specific depth (39+ waters)</td>
+          <td class="feature-name">Arkansas-specific depth (57 waters)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Real-time USGS / NWS data</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Condition-aware lure scoring</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Spawn phase tracking</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Free core (no paywall)</td>
           <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
         </tr>
         <tr>
           <td class="feature-name">Zero backend / GitHub Pages</td>
-          <td class="cell-yes pfg-col">&#x2705;</td>
+          <td class="cell-partial pfg-col">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Community / social catch log</td>
-          <td class="cell-soon pfg-col">&#x1F51C;</td>
+          <td class="cell-partial pfg-col">&#x26A0;&#xFE0F;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">AI fishing assistant</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Education / skill progression</td>
-          <td class="cell-soon pfg-col">&#x1F51C;</td>
+          <td class="cell-partial pfg-col">&#x26A0;&#xFE0F;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Gamification (badges / challenges)</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Paddler / kayak mode</td>
-          <td class="cell-soon pfg-col">&#x1F51C;</td>
+          <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">PWA / mobile install</td>
           <td class="cell-soon pfg-col">&#x1F51C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
+          <td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Bathymetric maps</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
         </tr>
         <tr>
           <td class="feature-name">Hardware (sonar/GPS) integration</td>
           <td class="cell-no pfg-col">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
         </tr>
         <tr>
           <td class="feature-name">Weekly digest / fishing reports</td>
-          <td class="cell-soon pfg-col">&#x1F51C;</td>
+          <td class="cell-yes pfg-col">&#x2705;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td><td class="cell-no">&#x274C;</td>
           <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-partial">&#x26A0;&#xFE0F;</td><td class="cell-yes">&#x2705;</td>
-          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td>
+          <td class="cell-no">&#x274C;</td><td class="cell-no">&#x274C;</td><td class="cell-yes">&#x2705;</td>
         </tr>
       </tbody>
     </table>
   </div>
   <div style="margin-top:16px; font-size:12px; color:var(--text-muted);">
-    PFG&rsquo;s structural moat: rows 1&ndash;6 (local depth, real-time data, condition scoring, spawn tracking, free core, zero-backend). No competitor matches these simultaneously for Arkansas. Roadmap rows 7&ndash;15 close the community and platform gaps. Hardware and bathymetric maps are intentionally out of scope.
+    PFG&rsquo;s structural moat: rows 1&ndash;5 (local depth, real-time data, condition scoring, spawn tracking, free core) plus a now-shipped Paddler mode and Weekly Report. No competitor matches these simultaneously for Arkansas. &ldquo;Zero backend&rdquo; is downgraded to partial this scan &mdash; the core product migrated to a Next.js/Supabase app (`paddler.html` is the one remaining static surface). Community/social and education are now partial, not just roadmap items, following this window&rsquo;s catch-reports and Pocket-Score shipping. Hardware and bathymetric maps are intentionally out of scope.
   </div>
 </div>
 
@@ -924,7 +946,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <li><strong>FishTips</strong> &mdash; Arkansas-specific, guide-authored reports (Lake Erling, Lake Conway, Arkansas River, Spring River) behind a subscription. No AI, no real-time USGS/NWS/AGFC data.</li>
       <li><strong>AGFC Mobile</strong> &mdash; Official state app for licensing only. No fishing intelligence. Highest-value partner target.</li>
       <li><strong>Fishbrain / FishAngler</strong> &mdash; Cover AR in national databases. No local depth, no USGS integration, no spawn phase data for AR species.</li>
-      <li><strong>Omnia Fishing</strong> &mdash; Crowd-sourced reports for some AR lakes. Shallow vs. PFG&rsquo;s 39-body real-time database.</li>
+      <li><strong>Omnia Fishing</strong> &mdash; Crowd-sourced reports for some AR lakes. Shallow vs. PFG&rsquo;s 57-body real-time database.</li>
       <li><strong>No competitor yet combines real-time USGS/NWS data, condition-aware lure scoring, and AGFC-cited reports for Arkansas.</strong> This is PFG&rsquo;s structural moat &mdash; now contested on positioning, not yet on data depth.</li>
     </ul>
   </div>
@@ -946,12 +968,12 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="canvas-cell span1">
       <div class="canvas-label">Solution</div>
       <ul>
-        <li><strong>39-body AR water database</strong> with real-time USGS/NWS feeds</li>
+        <li><strong>57-body AR water database</strong> (33 species) with real-time USGS/NWS/USACE feeds, now on a Next.js/Supabase production app</li>
         <li>Condition-aware lure scoring (clarity &times; flow &times; phase)</li>
+        <li>Pocket Score verdict engine (GO/SCOUT/HOLD + &ldquo;why&rdquo;) fusing live signals with AGFC-reported corroboration</li>
         <li>Spawn phase tracking for White Bass, Crappie + more</li>
-        <li>Zero paywall, zero backend &mdash; GitHub Pages</li>
-        <li>Education layer (planned): beginner &rarr; pro progression</li>
-        <li>Paddler mode (in development)</li>
+        <li>Zero paywall &mdash; user-submitted catch reports now live (photo, moderated)</li>
+        <li>Paddler mode shipped for the Buffalo National River; education curriculum still planned</li>
       </ul>
     </div>
     <div class="canvas-cell span2">
@@ -985,7 +1007,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="canvas-label">Key Metrics</div>
       <ul>
         <li><strong>Acquisition:</strong> Organic search, AGFC referral, editorial mentions</li>
-        <li><strong>Engagement:</strong> water_selected, species_toggled, tackle_box_opened</li>
+        <li><strong>Engagement:</strong> water_selected, species_toggled, tackle_box_opened, weekly-report views, catch-report submissions</li>
         <li><strong>Retention:</strong> Return visit rate, weekly digest opens</li>
         <li><strong>Revenue:</strong> Ko-fi donations, affiliate lure link clicks, future Patreon</li>
         <li><strong>Product:</strong> Spawn window accuracy &plusmn;3 days, p50 first-interaction &lt;3s</li>
@@ -1150,8 +1172,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">Onboarding &amp; Education</div>
-      <div class="rubric-desc">Fishbox&rsquo;s AI assistant and GilledIt&rsquo;s challenge system show beginners need guided onboarding. PFG&rsquo;s condition-aware lure scoring is powerful but not yet presented as a learning tool. Add &ldquo;why this lure?&rdquo; context to existing scored recommendations as a first step.</div>
-      <div class="rubric-score score-c">C</div>
+      <div class="rubric-desc"><strong>Upgraded this scan:</strong> the shipped Pocket Score engine now gives every verdict a contributor breakdown and a one-line &ldquo;why&rdquo; &mdash; exactly the context this rubric asked for. Still short of Fishbox/BassForecast&rsquo;s structured curriculum, but no longer a bare scoring number with no explanation.</div>
+      <div class="rubric-score score-b">B</div>
     </div>
     <div class="rubric-row">
       <div class="rubric-name">AI-Native Differentiation</div>
@@ -1175,8 +1197,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">Community &amp; Social</div>
-      <div class="rubric-desc">GilledIt, Fishbrain, FishAngler all have strong social flywheels. PFG has zero community features currently. Posting weekly condition reports to existing AR fishing Facebook groups requires no community features &mdash; start there before building backend infrastructure.</div>
-      <div class="rubric-score score-d">D</div>
+      <div class="rubric-desc"><strong>Upgraded this scan:</strong> user-submitted catch reports (photo, EXIF-verified, moderated) shipped this window &mdash; PFG&rsquo;s first real community feature. Still well short of GilledIt/Fishbrain/FishAngler&rsquo;s full social feeds and badges. Posting weekly condition reports to existing AR fishing Facebook groups remains a zero-cost next step.</div>
+      <div class="rubric-score score-c">C</div>
     </div>
   </div>
 
@@ -1191,7 +1213,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
         <p>Structure for pitching PFG to fishing app roundup editors:</p>
         <ul style="padding-left:16px; margin-top:8px;">
           <li><strong>Hook:</strong> &ldquo;The only free fishing app with real-time USGS water conditions for Arkansas &mdash; tells you exactly what lure to throw based on today&rsquo;s water clarity and flow.&rdquo;</li>
-          <li><strong>Differentiator:</strong> 39 Arkansas water bodies, condition-aware lure scoring, spawn phase tracking. Zero paywall.</li>
+          <li><strong>Differentiator:</strong> 57 Arkansas water bodies, condition-aware lure scoring, spawn phase tracking, Pocket Score &ldquo;why&rdquo; verdicts. Zero paywall.</li>
           <li><strong>Credibility:</strong> Built on GitHub Pages, open-source, powered by USGS/NWS public APIs.</li>
           <li><strong>CTA:</strong> Link to live app + 2&ndash;3 screenshots showing lure recommendations in action.</li>
         </ul>
@@ -1285,6 +1307,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 29, 2026</h3>
+    <ul>
+      <li><strong>Deep Dive added to tracking</strong> &mdash; a pro-intelligence bass fishing app featured live on Bassmaster/MLF/NPFL broadcasts (satellite clarity maps, lure recommendations, TVA dam-release schedules, free + Pro tier). No Arkansas presence found; relevant mainly as another AI-native, bass-focused entrant. 14 competitors now tracked, up from 13.</li>
+      <li><strong>onWater Fish&rsquo;s Arkansas data-depth check carried over a second scan.</strong> A direct site check was attempted again and blocked by the site&rsquo;s own bot protection; no new Arkansas-specific coverage surfaced elsewhere. Opportunity #1 stays open and is now flagged for a manual check rather than another automated attempt.</li>
+      <li><strong>Two new 2026 editorial roundups found and checked &mdash; PFG absent from both:</strong> Hook &amp; Barrel Magazine and Wish Upon A Fish (32 apps). Tracked roundup count rises from 6 to 8; PFG remains in none of them.</li>
+      <li><strong>FishAngler VIP backlash confirmed ongoing, with a partial company concession</strong> &mdash; free 7-day forecasts, marine data, SST, and currents added back after public criticism, but the solunar calendar and full forecast remain paywalled.</li>
+      <li><strong>The most significant finding this scan is PFG&rsquo;s own progress, not a competitor move:</strong> the product fully migrated off the legacy static site to a Next.js/Supabase app on Vercel, corrected its water count from 39 to the real 57 (33 species), and shipped a Pocket Score verdict engine (GO/SCOUT/HOLD + a &ldquo;why&rdquo; contributor breakdown), a statewide Weekly Report, and user-submitted catch reports (photo, moderated). This directly answers last scan&rsquo;s Opportunity #5 and moves two Best Practice rubric rows &mdash; Onboarding &amp; Education (C&rarr;B) and Community &amp; Social (D&rarr;C).</li>
+      <li><strong>Visibility did not move at all.</strong> Zero third-party mentions of PFG anywhere, still. Three consecutive scans of real product progress against a flat line on discovery is the clearest signal yet that the next scan should check for actual outreach (editorial pitch sent, AGFC contacted, app store listing filed) rather than more shipped features.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary

Routine Green Team competitive-intelligence scan for `competitive-dashboard.html`, following the established append-only History cadence (v1.4–v1.7). This is a scheduled monitoring pass, not a manually-scoped feature request.

- Added **Deep Dive** (Bassmaster/MLF/NPFL pro-intel bass fishing app) to competitor tracking — 14 competitors now tracked, up from 13. No Arkansas presence found; added to the Feature Matrix as an 11th competitor column.
- Confirmed PFG's continued absence from **two newly-discovered 2026 editorial roundups** (Hook & Barrel Magazine, Wish Upon A Fish) — tracked roundup count rises from 6 to 8, PFG in none of them.
- Confirmed **FishAngler VIP paywall backlash** is ongoing, with a partial company concession (some free features restored).
- Attempted a direct hands-on check of **onWater Fish's Arkansas data depth** (this dashboard's top-priority open item since the last scan) — blocked by the site's bot protection a second time; carried over with a note to do a manual/in-app check instead.
- Logged **PFG's own shipped roadmap progress** this window, since it materially changes several tracked items: full Next.js/Supabase migration off the legacy static site, a corrected water count (39 → 57 Arkansas waters / 33 species), a new Pocket Score verdict engine ("why" reasoning + contributor breakdown), a statewide Weekly Report, and user-submitted catch reports. This moved two Best Practice rubric rows (Onboarding & Education C→B, Community & Social D→C) and updated several Feature Matrix cells.
- No new PFG third-party mentions found anywhere (web, forums, social, app stores) — unchanged since tracking began.
- Appended a new `v1.8 · July 29, 2026` entry to the dashboard's History tab.

## Test plan

- [x] Verified HTML tag balance (div/table/tr/td counts match) after edits
- [x] Verified every Feature Matrix row has 11 data cells matching the 11-column header (PFG + 10 competitors)
- [ ] Human visual review of the rendered dashboard (open `competitive-dashboard.html` in a browser)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbruHii1KMTB9PNGCue5Tw)_