### PR TITLE
[Feature] Update PFG competitive intelligence dashboard — July 30 scan (v1.8)

### DIFF
--- a/competitive-dashboard.html
+++ b/competitive-dashboard.html
@@ -302,7 +302,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   </div>
   <div class="header-meta">
     <span class="badge badge-green">July 2026 Edition</span>
-    <div class="last-updated">Refreshed: July 8, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.7</div>
+    <div class="last-updated">Refreshed: July 30, 2026 &nbsp;&middot;&nbsp; Routine AI scan &nbsp;&middot;&nbsp; v1.8</div>
     <div style="margin-top:6px; display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end;">
       <span class="badge badge-muted">Pocket Fishing Guide v0.4.0</span>
       <span class="badge badge-blue">Arkansas Waters</span>
@@ -317,7 +317,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
   <div class="stat"><span class="stat-val">57.9M</span><span class="stat-label">US Anglers (2024)</span></div>
   <div class="stat"><span class="stat-val">23%</span><span class="stat-label">Angler Churn (2024)</span></div>
   <div class="summary-alert">
-    <strong>Signal:</strong> <strong>onWater Fish</strong> is now PFG&rsquo;s sharpest positioning collision, not a background watch item &mdash; it launched &ldquo;Angler Intelligence&trade;: the First AI-Native Fishing Experience&rdquo; (Oct 2025) with a patented AI trout-measuring tool, and already runs dedicated Arkansas pages today. Two more AI-native entrants (FishGuide AI, Fish AI) are now tracked. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
+    <strong>Signal:</strong> The generic &ldquo;AI fishing chatbot&rdquo; category is now commoditizing fast &mdash; at least six more single-purpose AI apps (AnglerAI, AINGLER, Fisher AI, AnglersAI, Fishing AI App, AI Angler) surfaced this scan alongside the existing watch-list, none Arkansas- or condition-aware. Separately, <strong>GilledIt</strong> introduced its first-ever paid tier (Pro, &pound;4.99/mo from month 6+, existing users free for 12 months) while keeping catch logging, social, and marketplace free forever &mdash; a live proof point for PFG&rsquo;s free-core-plus-upsell model, not a threat to it. Still zero third-party mentions of PFG anywhere &mdash; the visibility gap, not the product, remains the binding constraint.
   </div>
 </div>
 
@@ -343,44 +343,45 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
   <div class="grid-2" style="margin-bottom:20px;">
     <div class="report-block">
-      <h3>New Competitors &amp; Clones &mdash; July 2026</h3>
+      <h3>New Competitors &amp; Clones &mdash; July 30 Scan</h3>
       <ul>
-        <li><strong>onWater Fish is a materially closer competitor than previously tracked &mdash; escalated to High threat.</strong> It launched &ldquo;Angler Intelligence&trade; &mdash; the First AI-Native Fishing Experience&rdquo; (Oct 24, 2025): species ID and hands-off fish length/weight measurement from a photo (patented, beta, no reference object needed, 107 species), built on live gauge/weather/access data. It already runs dedicated Arkansas pages today &mdash; not a future threat. Its self-description (&ldquo;AI-native&rdquo;) is near-identical language to PFG&rsquo;s own positioning. Data depth on Arkansas specifically is unverified and should be checked directly against AGFC-level integration.</li>
-        <li><strong>Two new AI-native entrants added to tracking:</strong> FishGuide AI (App Store, shipped a v2.0 this window &mdash; Ice Fishing Mode, a Daily Bite Score 1&ndash;100 with 10-day forecast, a new Bite Times feature) and Fish AI (Google Play, added global leaderboards July 5, 2026; mixed sentiment &mdash; praised for its catch-collection &ldquo;Pokedex&rdquo; feel, criticized for slow fish ID and subscription practices).</li>
-        <li><strong>FishTips added &mdash; Arkansas-specific, guide-contributed model.</strong> Atlanta-based; has dedicated pages for Lake Erling, Lake Conway, Arkansas River, and Spring River with local reports and a subscription tier for hyper-current intel from &ldquo;digital guides.&rdquo; No AI, no real-time USGS/NWS data &mdash; content is guide-authored rather than data-driven, but it is a direct Arkansas-market competitor PFG had not been tracking.</li>
-        <li><strong>FishAngler&rsquo;s VIP paywall</strong> (flagged last scan) is unchanged this window &mdash; still gating FishForecast, solunar calendar, and exact location behind a new tier, still drawing user backlash.</li>
-        <li><strong>onX Fish</strong>&rsquo;s only new-market move remains Montana (May 2026, its home state) &mdash; no further movement toward Arkansas since the last scan. GilledIt&rsquo;s Fishial.AI photo ID remains on track for Q3 2026, unshipped.</li>
+        <li><strong>The generic AI-fishing-chatbot category is proliferating fast.</strong> Six additional single-purpose AI apps surfaced this scan and are now folded into the AI-Native watch-list group: AnglerAI (Abacus AI, Google Play), AINGLER (AI-judged tournament scoring, iOS/Android, live since 2024 with FishScore integration), Fisher AI: Fishing Spots (App Store), AnglersAI (App Store), Fishing AI App (App Store), and AI Angler: Fishing Predictions (Google Play). None are Arkansas- or condition-aware; all answer generic questions rather than scoring real local water data. The category is now crowded enough that &ldquo;has an AI chatbot&rdquo; is table stakes, not a differentiator &mdash; reinforces that PFG&rsquo;s planned Claude assistant needs to stay AGFC-cited and condition-aware to stand out.</li>
+        <li><strong>GilledIt introduced its first-ever paid tier.</strong> Pro launches at &pound;4.99/mo starting month 6+, with every existing user grandfathered into Pro free for 12 months; catch logging, social feed, marketplace, messaging, and basic stats remain free forever. This is a shift from &ldquo;pure free&rdquo; to freemium, but the core stays free &mdash; a live case study validating PFG&rsquo;s own free-core-plus-optional-upsell direction rather than undercutting it.</li>
+        <li><strong>Correction to a prior scan:</strong> the v1.5 entry (July 2, 2026) described Fishbrain&rsquo;s tackle marketplace shutdown as a new 2026 development. Re-verification this scan found the shutdown was actually announced in September 2023 (Fishbrain Dissolves Direct E-Commerce Marketplace). Flagging for the record; no change to Fishbrain&rsquo;s Low threat rating.</li>
+        <li><strong>onWater Fish, FishGuide AI, Fish AI, FishTips, and FishAngler&rsquo;s VIP paywall</strong> are all unchanged this window &mdash; no new feature launches, state expansions, or reversals detected since the July 8 scan.</li>
+        <li><strong>onX Fish</strong>&rsquo;s footprint remains unchanged at 11 states (still Montana as the newest, still Missouri as the nearest AR border); no movement toward Arkansas this window.</li>
         <li>No GitHub clones or App Store copycats of PFG&rsquo;s codebase were identified.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>PFG Mentions Across Web &amp; Communities</h3>
       <ul>
-        <li><strong>Public footprint confirmed, still first-party only.</strong> pocketfishinguide.com is live and Google-indexed (title: &ldquo;Fishing Intelligence | Tale Waters &amp; Tides&rdquo;), surfacing in search snippets for water/species/condition detail. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
-        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged since tracking began. Public footprint has begun; organic buzz has not.</li>
-        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site.</li>
-        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer.</li>
-        <li><strong>FishTips and onWater Fish</strong> both now show up ahead of PFG for Arkansas-specific fishing-app queries &mdash; a widening, not narrowing, visibility gap.</li>
+        <li><strong>Public footprint unchanged, still first-party only.</strong> pocketfishinguide.com/waters continues to surface directly in search results for &ldquo;Pocket Fishing Guide Arkansas app&rdquo;-style queries. This is the product&rsquo;s own site being indexed, not third-party coverage.</li>
+        <li><strong>Targeted searches across Reddit, X/Twitter, fishing forums, press, and app-store listings all still returned zero third-party results</strong> for &ldquo;Pocket Fishing Guide&rdquo; &mdash; unchanged for the fourth consecutive scan. Public footprint exists; organic buzz has not started.</li>
+        <li><strong>Still zero editorial mentions</strong> in any 2026 fishing app roundup or review site (FishingBooker, GilledIt, Kayak Angler, Fishbox, Guidesly, Wired2Fish all re-checked this window &mdash; no change).</li>
+        <li><strong>AGFC Mobile</strong> dominates Arkansas fishing app search results &mdash; licensing-only, no intelligence layer. AGFC also rolled out a new $10.50 WMA/Lake Conservation Permit effective July 1, 2026 (hiking, paddling, camping on AGFC land) &mdash; anglers with a valid fishing license are exempt, so no direct PFG impact, but it&rsquo;s a reminder AGFC is actively updating angler-facing policy and channels right now, a live window for outreach.</li>
+        <li><strong>FishTips and onWater Fish</strong> continue to out-rank PFG for Arkansas-specific fishing-app queries &mdash; visibility gap unchanged, not narrowing.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Competitor Moves vs. PFG Roadmap</h3>
       <ul>
-        <li><strong>Gamification is accelerating fast, industry-wide:</strong> Fish AI added global leaderboards (July 5), GilledIt ships challenges/badges/XP, Fishbuddy runs a 20-level XP system, and MyFishing Book uses Rookie&rarr;Elite tournament tiers &mdash; the nearest thing to a progression ladder found anywhere, though competition-framed rather than educational.</li>
-        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including the new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification-first direction.</li>
-        <li><strong>AI assistant / AI-native positioning:</strong> onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products. PFG&rsquo;s planned Claude API assistant needs to stay condition-aware and AGFC-cited to avoid reading as &ldquo;yet another generic AI fishing chatbot.&rdquo;</li>
-        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item.</li>
-        <li><strong>Android expansion:</strong> onX Fish&rsquo;s footprint still reaches Missouri, on Arkansas&rsquo;s border, unchanged this window.</li>
+        <li><strong>Freemium monetization gets a second live proof point:</strong> GilledIt&rsquo;s new Pro tier (&pound;4.99/mo, month 6+, core free forever, 12-month grandfather period for existing users) mirrors the exact free-core-plus-upsell shape PFG&rsquo;s roadmap already assumes (Ko-fi &rarr; affiliate &rarr; Patreon). Worth studying GilledIt&rsquo;s specific Pro feature cut when PFG scopes its own premium tier.</li>
+        <li><strong>AI assistant / AI-native positioning is now crowded, not novel.</strong> onWater Fish, FishGuide AI, Fish AI, and at least six newly surfaced generic AI apps (AnglerAI, AINGLER, Fisher AI, AnglersAI, Fishing AI App, AI Angler) are all live AI-forward products. A bare &ldquo;AI assistant&rdquo; is no longer a differentiator industry-wide &mdash; PFG&rsquo;s planned Claude API assistant needs a specific, defensible angle (AGFC-cited, condition-aware, Arkansas-only) to avoid reading as one more entrant in an increasingly commoditized category.</li>
+        <li><strong>Beginner&rarr;expert education path: still unclaimed.</strong> No competitor, including any new adds this window, has shipped a true educational skill-progression arc. This white space remains PFG&rsquo;s cleanest differentiator versus the industry&rsquo;s gamification- and AI-chat-first direction.</li>
+        <li><strong>Community catch logging:</strong> GilledIt, Fishbrain, FishAngler all have robust social logs. PFG has this as a &ldquo;Later&rdquo; backend item; unchanged this window.</li>
+        <li><strong>State-footprint expansion:</strong> onX Fish&rsquo;s footprint still tops out at Missouri on Arkansas&rsquo;s border, unchanged since May 2026.</li>
       </ul>
     </div>
     <div class="report-block">
       <h3>Market Sentiment &amp; Opportunities</h3>
       <ul>
-        <li><strong>Paywalls are the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s new VIP tier are the most-cited negatives across 2026 reviews. PFG&rsquo;s free model is a genuine differentiator.</li>
-        <li><strong>Record participation, record churn.</strong> RBFF/Outdoor Foundation: 57.9M Americans fished in 2024 (record high, 19% participation), but the industry lost 16.6M anglers the same year &mdash; a 23% one-year churn rate, up from 18% five years ago. 85% of anglers started before age 12, but participation drops sharply after 18, and female youth quit at an 11% higher rate than male youth. This is a strong signal for retention-focused UX (already on PFG&rsquo;s roadmap under User Retention &amp; Personalization).</li>
-        <li><strong>Beginners underserved:</strong> Fishbox explicitly targets new anglers; no competitor has shipped structured education. PFG&rsquo;s education roadmap addresses both the largest untapped segment and the churn problem above.</li>
-        <li><strong>Local depth wins &mdash; but the field just got more crowded.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. onWater Fish and FishTips both now claim Arkansas presence, but neither has confirmed AGFC-level data depth &mdash; verify directly before conceding any ground.</li>
-        <li><strong>AGFC partnership:</strong> The state app is a license tool only. A referral or co-promotion from AGFC bypasses all organic discovery friction and would be hard for onWater/FishTips to replicate quickly.</li>
+        <li><strong>Paywalls remain the top complaint:</strong> Fishbrain&rsquo;s $10&ndash;13/mo paywall and FishAngler&rsquo;s VIP tier are still the most-cited negatives across 2026 reviews and intel reports; FishAngler&rsquo;s sentiment trend is confirmed declining this window. PFG&rsquo;s free model remains a genuine differentiator, now reinforced (not undercut) by GilledIt&rsquo;s grandfathered freemium launch.</li>
+        <li><strong>Market size holding steady:</strong> re-confirmed this scan at $217.27M (2026) growing to $587.14M by 2035 at an 11.68% CAGR &mdash; no revision to prior figures.</li>
+        <li><strong>Record participation, record churn &mdash; unchanged.</strong> RBFF/Outdoor Foundation figures (57.9M anglers 2024, 23% one-year churn) still stand as the most current data available; still a strong signal for PFG&rsquo;s retention/onboarding roadmap item.</li>
+        <li><strong>Beginners underserved:</strong> still only Fishbox explicitly targets new anglers; no competitor, including this window&rsquo;s new AI-app adds, has shipped structured education. PFG&rsquo;s education roadmap still addresses the largest untapped segment.</li>
+        <li><strong>Local depth wins &mdash; still contested, not lost.</strong> No app combines 39+ Arkansas water bodies with real-time USGS/NWS data and condition-aware scoring the way PFG does. The onWater Fish hands-on depth check (Opportunity #0/1) has not yet been reported done &mdash; still the single highest-leverage next action.</li>
+        <li><strong>AGFC partnership window is live:</strong> the agency just pushed a new $10.50 conservation-permit policy (July 1, 2026) and is visibly active in digital/press channels right now &mdash; a good moment to reach their team while a policy change is fresh in anglers&rsquo; minds.</li>
       </ul>
     </div>
   </div>
@@ -459,6 +460,13 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     <div class="source-item"><a href="https://fishtips.com/states/arkansas" target="_blank">FishTips &mdash; Arkansas Guides, Reports &amp; Local Tips</a></div>
     <div class="source-item"><a href="https://asafishing.org/wp-content/uploads/2025/07/2025-Special-Report-Infographic.pdf" target="_blank">RBFF / ASA &mdash; 2025 Special Report on Fishing (57.9M anglers, 23% churn)</a></div>
     <div class="source-item"><a href="https://www.nmma.org/press/article/25183" target="_blank">NMMA &mdash; Record High Fishing Participation Reached in 2024</a></div>
+    <div class="source-item"><a href="https://www.gilledit.com/us" target="_blank">GilledIt &mdash; Pro Tier Announcement (&pound;4.99/mo, month 6+)</a></div>
+    <div class="source-item"><a href="https://fishingtackleretailer.com/fishbrain-dissolves-direct-e-commerce-marketplace/" target="_blank">Fishing Tackle Retailer &mdash; Fishbrain Dissolves Marketplace (Sept 2023, correction)</a></div>
+    <div class="source-item"><a href="https://play.google.com/store/apps/details?id=app.abacusai.anglerai.twa" target="_blank">AnglerAI (Abacus AI) &mdash; Google Play</a></div>
+    <div class="source-item"><a href="https://www.aingler.ai/" target="_blank">AINGLER &mdash; AI Fishing Tournament Judging</a></div>
+    <div class="source-item"><a href="https://apps.apple.com/us/app/-/id6755977756" target="_blank">Fisher AI: Fishing Spots &mdash; App Store</a></div>
+    <div class="source-item"><a href="https://www.agfc.com/resources/licensing/agfc-owned-wma-lake-conservation-permit-wmc/" target="_blank">AGFC &mdash; New $10.50 WMA/Lake Conservation Permit (July 1, 2026)</a></div>
+    <div class="source-item"><a href="https://marlvel.ai/intel-report/sports/fishangler-fish-finder-app" target="_blank">Marlvel &mdash; FishAngler 2026 Sentiment &amp; Intel Report</a></div>
   </div>
 </div>
 
@@ -478,7 +486,8 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       </div>
       <div class="tags"><span class="tag">Free</span><span class="tag">Gamified</span><span class="tag">Marketplace</span><span class="tag">200+ Species</span><span class="tag">Challenges</span></div>
       <div id="d-gilledit" class="details-panel">
-        <p><strong>What they do:</strong> Catch logging, social feed, built-in tackle marketplace, weekly challenges, 30+ badges, 200+ US species. No paywall on core features. Named #1 in all six major 2026 roundups reviewed. <strong>Photo-based fish identification powered by Fishial.AI is confirmed for Q3 2026.</strong></p>
+        <p><strong>What they do:</strong> Catch logging, social feed, built-in tackle marketplace, weekly challenges, 30+ badges, 200+ US species. Named #1 in all six major 2026 roundups reviewed. <strong>Photo-based fish identification powered by Fishial.AI is confirmed for Q3 2026.</strong></p>
+        <p style="margin-top:8px;"><strong>Update (July 30, 2026):</strong> Announced its first-ever paid tier &mdash; Pro at &pound;4.99/mo, launching month 6+, with every existing user grandfathered into Pro free for 12 months. Catch logging, social, marketplace, messaging, push, and basic stats remain free forever &mdash; this is freemium, not a pivot away from free-core.</p>
         <p style="margin-top:8px;"><strong>Edge over PFG:</strong> National reach, gamification, community, tackle commerce, editorial presence, and soon AI fish ID.</p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Arkansas-depth intelligence, real-time USGS/NWS, condition-aware lure scoring. GilledIt has no local water data for AR.</p>
         <p style="margin-top:8px;"><a href="https://www.gilledit.com" target="_blank">gilledit.com &#x2197;</a></p>
@@ -497,7 +506,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
       <div class="tags"><span class="tag">20M Catches</span><span class="tag">AI Forecasts</span><span class="tag">Lake Maps</span><span class="tag">Paywalled</span></div>
       <div id="d-fishbrain" class="details-panel">
         <p><strong>What they do:</strong> 20M+ logged catches, AI fish forecasts, smart fishing points, weather/tides/moon, 30+ state license info, top bait recommendations.</p>
-        <p style="margin-top:8px;"><strong>Weakness:</strong> Heavy $10&ndash;13/month paywall is the most-cited negative in every 2026 review. Locks almost everything useful behind Pro. Its tackle marketplace has now been <strong>quietly shut down</strong> &mdash; a bolted-on commerce feature that didn&rsquo;t stick.</p>
+        <p style="margin-top:8px;"><strong>Weakness:</strong> Heavy $10&ndash;13/month paywall is the most-cited negative in every 2026 review. Locks almost everything useful behind Pro. Its direct tackle marketplace was dissolved in favor of retailer partnerships <strong>(correction: this happened in September 2023, not 2026 as an earlier scan stated &mdash; noted for the record, no rating change).</strong></p>
         <p style="margin-top:8px;"><strong>PFG edge:</strong> Free, local depth, real-time state data. Fishbrain users frustrated by paywall are natural PFG converts if PFG gains visibility.</p>
         <p style="margin-top:8px;"><a href="https://fishbrain.com/features" target="_blank">fishbrain.com &#x2197;</a></p>
       </div>
@@ -682,19 +691,19 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 
     <div class="card">
       <div class="card-header" onclick="toggleDetails('d-ainative')" style="cursor:pointer;">
-        <div><div class="card-title">AI-Native Fishing Apps</div><div class="card-sub">FishGPT &middot; Fish AI &middot; Fishial.AI &middot; New Category</div></div>
+        <div><div class="card-title">AI-Native Fishing Apps</div><div class="card-sub">9 Apps Tracked &middot; Commoditizing Category</div></div>
         <span class="badge badge-muted">Low Threat</span>
       </div>
       <div class="threat-meter">
-        <div class="threat-label"><span>Threat to PFG</span><span>Low (watch-list)</span></div>
-        <div class="threat-bar"><div class="threat-fill threat-low" style="width:15%"></div></div>
+        <div class="threat-label"><span>Threat to PFG</span><span>Low individually, rising collectively (watch-list)</span></div>
+        <div class="threat-bar"><div class="threat-fill threat-low" style="width:20%"></div></div>
       </div>
-      <div class="tags"><span class="tag">Chatbot Q&amp;A</span><span class="tag">Photo Fish ID</span><span class="tag">Generic</span><span class="tag">No Local Data</span></div>
+      <div class="tags"><span class="tag">Chatbot Q&amp;A</span><span class="tag">Photo Fish ID</span><span class="tag">Generic</span><span class="tag">No Local Data</span><span class="tag">9 Apps</span></div>
       <div id="d-ainative" class="details-panel">
-        <p><strong>What they do:</strong> A new wave of single-purpose AI apps &mdash; FishGPT (chat assistant), Fish AI (location + species chat), and standalone Fishial.AI (photo identification, also licensed by GilledIt). All launched or gained traction in 2026.</p>
-        <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions rather than scoring real water data. Worth a quarterly recheck in case one adds state-level intelligence.</p>
-        <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware and Arkansas-specific to avoid competing head-on with these generalists.</p>
-        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a></p>
+        <p><strong>What they do:</strong> A fast-growing wave of single-purpose AI apps: FishGPT, Fish AI, standalone Fishial.AI (also licensed by GilledIt), and &mdash; newly surfaced this scan (July 30) &mdash; AnglerAI (Abacus AI), AINGLER (AI-judged tournament scoring, live since 2024, FishScore integration), Fisher AI: Fishing Spots, AnglersAI, Fishing AI App, and AI Angler: Fishing Predictions. Nine apps now grouped under this watch-list, up from three at the last scan.</p>
+        <p style="margin-top:8px;"><strong>Threat:</strong> None are Arkansas- or condition-aware; they answer generic questions or judge tournament catches rather than scoring real local water data. The category&rsquo;s rapid growth is itself the signal &mdash; &ldquo;has an AI assistant&rdquo; is becoming table stakes across the whole fishing-app market, not a PFG-specific differentiator.</p>
+        <p style="margin-top:8px;"><strong>PFG edge:</strong> Real-time USGS/NWS scoring beats a generic chatbot for on-the-water decisions. PFG&rsquo;s planned Claude API assistant should stay condition-aware, AGFC-cited, and Arkansas-specific to avoid reading as the tenth entrant in this generalist cluster.</p>
+        <p style="margin-top:8px;"><a href="https://fishgpt.com/" target="_blank">fishgpt.com &#x2197;</a> &middot; <a href="https://www.fishial.ai/" target="_blank">fishial.ai &#x2197;</a> &middot; <a href="https://www.aingler.ai/" target="_blank">aingler.ai &#x2197;</a></p>
       </div>
     </div>
 
@@ -1135,7 +1144,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">Free Core Model</div>
-      <div class="rubric-desc">Fishbrain&rsquo;s paywall is its #1 cited weakness in every 2026 review. FishAngler just proved the same lesson live: it paywalled its FishForecast and location features behind a new VIP tier in July 2026 and is taking real user backlash for it. GilledIt&rsquo;s free model keeps growing. PFG&rsquo;s free-forever philosophy is strategically correct &mdash; monetize through donations, affiliates, and premium guides, not feature gating.</div>
+      <div class="rubric-desc">Fishbrain&rsquo;s paywall is its #1 cited weakness in every 2026 review. FishAngler proved the same lesson live: it paywalled FishForecast and location features behind a VIP tier and is taking real user backlash for it. GilledIt now offers a second data point in the other direction &mdash; it just launched its first paid tier (&pound;4.99/mo) but kept every core feature free forever and grandfathered existing users into Pro for a year, i.e. freemium done right rather than a retreat from free. PFG&rsquo;s free-forever philosophy is strategically correct &mdash; monetize through donations, affiliates, and premium guides, not feature gating.</div>
       <div class="rubric-score score-a">A</div>
     </div>
     <div class="rubric-row">
@@ -1155,7 +1164,7 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
     </div>
     <div class="rubric-row">
       <div class="rubric-name">AI-Native Differentiation</div>
-      <div class="rubric-desc">onWater Fish, FishGuide AI, and Fish AI are all now live AI-forward products, and onWater&rsquo;s &ldquo;AI-native&rdquo; branding is near-identical to PFG&rsquo;s own language. PFG&rsquo;s planned Claude API assistant needs a specific, defensible angle &mdash; AGFC-cited, condition-aware, Arkansas-only &mdash; to avoid reading as one more generic AI fishing chatbot once it ships.</div>
+      <div class="rubric-desc">The generic AI-fishing-chatbot category grew from 3 to 9 tracked apps in one scan cycle (AnglerAI, AINGLER, Fisher AI, AnglersAI, Fishing AI App, and AI Angler joined FishGPT, Fish AI, and Fishial.AI this window), and onWater&rsquo;s &ldquo;AI-native&rdquo; branding is near-identical to PFG&rsquo;s own language. &ldquo;Has an AI assistant&rdquo; is now close to table stakes industry-wide. PFG&rsquo;s planned Claude API assistant needs a specific, defensible angle &mdash; AGFC-cited, condition-aware, Arkansas-only &mdash; to avoid reading as the tenth generic AI fishing chatbot once it ships.</div>
       <div class="rubric-score score-c">C</div>
     </div>
     <div class="rubric-row">
@@ -1285,6 +1294,18 @@ table.matrix { width: 100%; border-collapse: collapse; font-size: 12px; }
 <!-- TAB 8: History -->
 <div id="tab-history" class="tab-panel">
   <div class="info-box">Append-only scan log &mdash; each entry is one routine competitive-monitoring pass. Kept so drift and new signals are visible over time, not just in the latest snapshot.</div>
+
+  <div class="report-block" style="margin-bottom:16px;">
+    <h3>v1.8 &middot; July 30, 2026</h3>
+    <ul>
+      <li><strong>Generic AI-fishing-chatbot category tripled in one cycle.</strong> Six newly surfaced apps (AnglerAI/Abacus AI, AINGLER, Fisher AI: Fishing Spots, AnglersAI, Fishing AI App, AI Angler: Fishing Predictions) joined the existing FishGPT/Fish AI/Fishial.AI watch-list, bringing the group from 3 to 9 tracked apps. None are Arkansas- or condition-aware; the Best Practices &ldquo;AI-Native Differentiation&rdquo; rubric row and the AI-Native Fishing Apps competitor card were both updated to reflect that a bare AI assistant is now close to table stakes, not a differentiator.</li>
+      <li><strong>GilledIt launched its first-ever paid tier</strong> &mdash; Pro at &pound;4.99/mo from month 6+, with existing users grandfathered into Pro free for 12 months, while catch logging, social, marketplace, messaging, and basic stats stay free forever. Read as a live validation of PFG&rsquo;s free-core-plus-upsell roadmap direction, not a threat; Best Practices &ldquo;Free Core Model&rdquo; row updated accordingly (still A).</li>
+      <li><strong>Research correction:</strong> the v1.5 entry (July 2, 2026) reported Fishbrain&rsquo;s tackle-marketplace shutdown as a new 2026 development. Re-verification found it was actually announced in September 2023. Corrected in the Fishbrain competitor card; no threat-rating change.</li>
+      <li><strong>PFG mentions unchanged for a fourth consecutive scan:</strong> public site remains first-party-indexed only; zero third-party mentions across Reddit, X, forums, press, or app stores; zero editorial roundup inclusions. The onWater Fish hands-on Arkansas-depth check (Opportunity #1, flagged July 8) has still not been reported done and remains the single highest-leverage next action.</li>
+      <li><strong>Minor market context:</strong> AGFC introduced a new $10.50 WMA/Lake Conservation Permit for AGFC-owned land/lakes effective July 1, 2026 (licensed anglers exempt) &mdash; no direct PFG impact, but signals AGFC is actively updating angler-facing policy and channels right now, a timely window for the standing AGFC partnership outreach ask.</li>
+      <li>Market size, CAGR, and RBFF churn figures re-verified unchanged from the July 8 scan. No new Arkansas-specific competitors, PFG clones, or state-expansion moves (onX Fish, onWater Fish) detected this window.</li>
+    </ul>
+  </div>
 
   <div class="report-block" style="margin-bottom:16px;">
     <h3>v1.7 &middot; July 8, 2026</h3>


### PR DESCRIPTION
## Summary

Routine competitive-intelligence scan for Pocket Fishing Guide, per the scheduled monitoring task. Updates `competitive-dashboard.html` to v1.8 (July 30, 2026) with fresh web research since the July 8 scan (v1.7).

- **AI-fishing-chatbot category tripled** — 6 newly surfaced single-purpose AI apps (AnglerAI/Abacus AI, AINGLER, Fisher AI, AnglersAI, Fishing AI App, AI Angler) joined the existing 3-app watch-list. Updated the AI-Native Fishing Apps competitor card and the Best Practices "AI-Native Differentiation" rubric row to reflect that a bare AI assistant is now close to table stakes, not a differentiator.
- **GilledIt launched its first paid tier** — Pro at £4.99/mo from month 6+, existing users grandfathered free for 12 months, core stays free forever. Read as a live proof point for PFG's own free-core-plus-upsell direction. Updated the GilledIt competitor card and the "Free Core Model" rubric row.
- **Research correction** — the v1.5 History entry (July 2, 2026) described Fishbrain's tackle-marketplace shutdown as a new 2026 development; re-verification found it was actually announced in September 2023. Corrected in the Fishbrain competitor card and logged in the new History entry.
- **PFG visibility check** — still zero third-party mentions across Reddit, X, forums, press, app stores, or editorial roundups (4th consecutive scan unchanged). The onWater Fish hands-on Arkansas-depth check (Opportunity #1) still hasn't been reported done.
- Minor market context: new AGFC $10.50 WMA/Lake Conservation Permit (July 1, 2026) noted as a timely window for the standing AGFC partnership outreach ask.
- Market size, CAGR, and RBFF churn figures re-verified unchanged from the last scan.
- Appended a new `v1.8 · July 30, 2026` entry to the History tab (append-only log, per the existing pattern).

## Test plan

- [x] Verified `<div>`/`</div>` tag counts balance (412/412) after edits
- [x] Reviewed full diff for consistency across header, report tab, competitor cards, rubric, and history sections
- [ ] Open in browser to visually confirm tab navigation and new content render correctly (no build step — static HTML)

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01SB5pAMU1PVViQm8FHYHdaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SB5pAMU1PVViQm8FHYHdaW)_